### PR TITLE
IFNRA-4960 Use https to fetch opensourced repos

### DIFF
--- a/datadog.tf
+++ b/datadog.tf
@@ -1,7 +1,7 @@
 module "datadog_monitoring" {
   count = var.monitoring_enabled ? 1 : 0
 
-  source = "git@github.com:worldcoin/terraform-datadog-kubernetes?ref=v1.2.2"
+  source = "git::https://github.com/worldcoin/terraform-datadog-kubernetes?ref=v1.2.2"
 
   notification_channel = var.monitoring_notification_channel
   service              = format("EKS %s", var.cluster_name)

--- a/kubernetes-traefik-external.tf
+++ b/kubernetes-traefik-external.tf
@@ -93,7 +93,7 @@ resource "kubernetes_ingress_v1" "treafik_ingress" {
 }
 
 module "alb" {
-  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=v0.17.0"
+  source   = "git::https://github.com/worldcoin/terraform-aws-alb.git?ref=v0.17.0"
   for_each = var.external_alb_enabled ? toset([local.external_alb_name]) : []
 
   # because of lenght limitation of LB name we need to remove prefix treafik from internal NLB

--- a/kubernetes-traefik-internal.tf
+++ b/kubernetes-traefik-internal.tf
@@ -63,7 +63,7 @@ resource "kubernetes_service" "traefik_nlb" {
 }
 
 module "nlb" {
-  source = "git@github.com:worldcoin/terraform-aws-nlb.git?ref=v0.7.0"
+  source = "git::https://github.com/worldcoin/terraform-aws-nlb.git?ref=v0.7.0"
 
   for_each = var.internal_nlb_enabled ? toset([local.internal_nlb_name]) : []
 


### PR DESCRIPTION
https://linear.app/worldcoin/issue/INFRA-4960/fix-validation-for-tfh-eks-module-in-wf-action

Switching to https  to enable fetching by external parties without gh auth

<img width="829" height="1155" alt="image" src="https://github.com/user-attachments/assets/a2b51e16-0c0f-48fa-872f-8bad7e4284d6" />
