### PR TITLE
INFRA-5029(aws-load-balancer): Add variable to control AWS Load Balancer IAM role creation

### DIFF
--- a/iam-aws-load-balancer.tf
+++ b/iam-aws-load-balancer.tf
@@ -338,7 +338,7 @@ resource "aws_iam_role" "aws_load_balancer" {
 resource "aws_iam_role_policy" "aws_load_balancer" {
   count  = var.aws_load_balancer_iam_role_enabled ? 1 : 0
   name   = "aws-load-balancer-controller-${var.cluster_name}"
-  role   = aws_iam_role.aws_load_balancer.id
+  role   = aws_iam_role.aws_load_balancer[0].id
   policy = data.aws_iam_policy_document.aws_load_balancer.json
 }
 

--- a/iam-aws-load-balancer.tf
+++ b/iam-aws-load-balancer.tf
@@ -329,13 +329,25 @@ data "aws_iam_policy_document" "aws_load_balancer" {
 }
 
 resource "aws_iam_role" "aws_load_balancer" {
+  count              = var.aws_load_balancer_iam_role_enabled ? 1 : 0
   name               = "aws-load-balancer-controller-${var.cluster_name}"
   path               = "/system/"
   assume_role_policy = data.aws_iam_policy_document.aws_load_balancer_assume_role_policy.json
 }
 
 resource "aws_iam_role_policy" "aws_load_balancer" {
+  count  = var.aws_load_balancer_iam_role_enabled ? 1 : 0
   name   = "aws-load-balancer-controller-${var.cluster_name}"
   role   = aws_iam_role.aws_load_balancer.id
   policy = data.aws_iam_policy_document.aws_load_balancer.json
+}
+
+moved {
+  from = aws_iam_role.aws_load_balancer
+  to   = aws_iam_role.aws_load_balancer[0]
+}
+
+moved {
+  from = aws_iam_role_policy.aws_load_balancer
+  to   = aws_iam_role_policy.aws_load_balancer[0]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -656,3 +656,9 @@ variable "vpc_cni_external_snat" {
   type        = string
   default     = false
 }
+
+variable "aws_load_balancer_iam_role_enabled" {
+  description = "Whether to enable the IAM role for the AWS Load Balancer"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-5029/add-feature-flag-to-disbale-aws-load-balancer-iam-role
Tested (yes/no): yes https://github.com/worldcoin-foundation/ampc-hnsw-setup/pull/88
Description/Why: in order to reuse an existing role, we shouldn't create a new one in the module, and adding a flag will enable us to do that