### PR TITLE
INFRA-5048: add workflow update-terraform-modules to repo

### DIFF
--- a/.github/workflows/update-terraform-modules.yml
+++ b/.github/workflows/update-terraform-modules.yml
@@ -1,0 +1,46 @@
+name: update-terraform-modules
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (must start with v, e.g., v1.2.3)'
+        required: true
+        type: string
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-deployment:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
+    runs-on: arc-medium-arm64-runner
+
+    steps:
+      - name: Validate version format
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          version="$VERSION"
+          if [[ ! $version =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Invalid version format. Version must start with 'v' followed by semantic version (e.g., v1.2.3)"
+            echo "Provided version: $version"
+            exit 1
+          fi
+          echo "Version format is valid: $version"
+      
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0
+        with:
+          token: ${{ secrets.GIT_HUB_TOKEN }}
+          repository: worldcoin/backstage-terraform-templates
+          event-type: update-terraform-modules
+          client-payload: |
+            {
+              "version": "${{ github.event.inputs.version || github.event.release.tag_name }}",
+              "issuer":  "${{ github.event.release.html_url || github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}",
+              "repo": "${{ github.repository }}"
+            }


### PR DESCRIPTION
Requestor/Issue: @tcharewicz
Tested (yes/no): no, this PR is a test
Description/Why: While we release a new version of terraform-aws-modules, this workflow will launch remote workflow in repo backstage-templates and update reference to the latest version of modules in templates. New resources allweys will be build with the latest version of module, less work for dependabot and merge-a-saurus.