### PR TITLE
remove hyphens in the end of lb name, it's not allowed

### DIFF
--- a/kubernetes-traefik-external.tf
+++ b/kubernetes-traefik-external.tf
@@ -93,7 +93,7 @@ resource "kubernetes_ingress_v1" "treafik_ingress" {
 }
 
 module "alb" {
-  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=v0.17.0"
+  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=remove-hyphens-in-the-end-of-lb-name"
   for_each = var.external_alb_enabled ? toset([local.external_alb_name]) : []
 
   # because of lenght limitation of LB name we need to remove prefix treafik from internal NLB

--- a/kubernetes-traefik-external.tf
+++ b/kubernetes-traefik-external.tf
@@ -93,7 +93,7 @@ resource "kubernetes_ingress_v1" "treafik_ingress" {
 }
 
 module "alb" {
-  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=remove-hyphens-in-the-end-of-lb-name"
+  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=v0.19.0"
   for_each = var.external_alb_enabled ? toset([local.external_alb_name]) : []
 
   # because of lenght limitation of LB name we need to remove prefix treafik from internal NLB

--- a/kubernetes-traefik-internal.tf
+++ b/kubernetes-traefik-internal.tf
@@ -63,7 +63,7 @@ resource "kubernetes_service" "traefik_nlb" {
 }
 
 module "nlb" {
-  source = "git@github.com:worldcoin/terraform-aws-nlb.git?ref=v0.7.0"
+  source = "git@github.com:worldcoin/terraform-aws-nlb.git?ref=remove-hyphens-in-the-end-of-lb-name"
 
   for_each = var.internal_nlb_enabled ? toset([local.internal_nlb_name]) : []
 

--- a/kubernetes-traefik-internal.tf
+++ b/kubernetes-traefik-internal.tf
@@ -63,7 +63,7 @@ resource "kubernetes_service" "traefik_nlb" {
 }
 
 module "nlb" {
-  source = "git@github.com:worldcoin/terraform-aws-nlb.git?ref=remove-hyphens-in-the-end-of-lb-name"
+  source = "git@github.com:worldcoin/terraform-aws-nlb.git?ref=v1.1.0"
 
   for_each = var.internal_nlb_enabled ? toset([local.internal_nlb_name]) : []
 

--- a/kubernetes-traefik-internal.tf
+++ b/kubernetes-traefik-internal.tf
@@ -78,8 +78,8 @@ module "nlb" {
 
   acm_arn         = var.internal_nlb_acm_arn != "" ? var.internal_nlb_acm_arn : var.traefik_cert_arn
   vpc_id          = var.vpc_config.vpc_id
-  public_subnets  = var.use_private_subnets_for_internal_nlb ? null : var.vpc_config.public_subnets
-  private_subnets = var.use_private_subnets_for_internal_nlb ? var.vpc_config.private_subnets : null
+  public_subnets  = var.use_private_subnets_for_internal_nlb ? [] : var.vpc_config.public_subnets
+  private_subnets = var.use_private_subnets_for_internal_nlb ? var.vpc_config.private_subnets : []
 
   extra_listeners = var.extra_nlb_listeners
 }


### PR DESCRIPTION
Requestor/Issue: @tcharewicz
Tested (yes/no): no, this PR is a test
Description/Why: While create EKS cluster for world-chat-service-prod in eu-west-1 regions, I have a error related to the name of ALB where it's end with hyphens. Link to TFE run https://tfe.worldcoin.dev/app/TFH/workspaces/world-chat-service-prod-eu-west-1/runs/run-7mf59FiKDk8zwZWg and screenshot for it.

<img width="1079" height="143" alt="Screenshot 2025-08-11 at 08 07 52" src="https://github.com/user-attachments/assets/de720358-452a-4d54-8612-c90fa79b2294" />

Description for Name variable for resource
name - (Optional) Name of the LB. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified, Terraform will autogenerate a name beginning with tf-lb.

This Pull Request remove hyphens from the end of LB name, once.