### PR TITLE
removes one of the annoying warnings in TF logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ index a95261645..9cf8d04b9 100644
 -  source = "git@github.com:worldcoin/terraform-aws-eks?ref=v4.4.2"
 +  source = "git@github.com:worldcoin/terraform-aws-eks?ref=v4.5.0"
 
-   cluster_name       = format("tools-%s-%s", var.environment, data.aws_region.current.name)
+   cluster_name       = format("tools-%s-%s", var.environment, data.aws_region.current.region)
    cluster_version    = "1.32"
 ```
 
@@ -334,7 +334,7 @@ index a95261645..9cf8d04b9 100644
 @@ -17,7 +17,7 @@ module "eks" {
    source = "git@github.com:worldcoin/terraform-aws-eks?ref=v4.5.0"
 
-   cluster_name       = format("tools-%s-%s", var.environment, data.aws_region.current.name)
+   cluster_name       = format("tools-%s-%s", var.environment, data.aws_region.current.region)
 -  cluster_version    = "1.31"
 +  cluster_version    = "1.32"
    environment        = var.environment

--- a/iam-karpenter.tf
+++ b/iam-karpenter.tf
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "karpenter" {
     sid       = "EKSClusterEndpointLookup"
     effect    = "Allow"
     actions   = ["eks:DescribeCluster"]
-    resources = ["arn:aws:eks:${data.aws_region.current.name}:${data.aws_caller_identity.account.id}:cluster/${var.cluster_name}"]
+    resources = ["arn:aws:eks:${data.aws_region.current.region}:${data.aws_caller_identity.account.id}:cluster/${var.cluster_name}"]
   }
   statement {
     sid       = "AllowScopedInstanceProfileCreationActions"
@@ -83,7 +83,7 @@ data "aws_iam_policy_document" "karpenter" {
     condition {
       test     = "StringEquals"
       variable = "aws:RequestTag/topology.kubernetes.io/region"
-      values   = [data.aws_region.current.name]
+      values   = [data.aws_region.current.region]
     }
     condition {
       test     = "StringLike"
@@ -106,7 +106,7 @@ data "aws_iam_policy_document" "karpenter" {
     condition {
       test     = "StringEquals"
       variable = "aws:RequestTag/topology.kubernetes.io/region"
-      values   = [data.aws_region.current.name]
+      values   = [data.aws_region.current.region]
     }
     condition {
       test     = "StringEquals"
@@ -116,7 +116,7 @@ data "aws_iam_policy_document" "karpenter" {
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceTag/topology.kubernetes.io/region"
-      values   = [data.aws_region.current.name]
+      values   = [data.aws_region.current.region]
     }
     condition {
       test     = "StringLike"
@@ -146,7 +146,7 @@ data "aws_iam_policy_document" "karpenter" {
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceTag/topology.kubernetes.io/region"
-      values   = [data.aws_region.current.name]
+      values   = [data.aws_region.current.region]
     }
     condition {
       test     = "StringLike"

--- a/kms.tf
+++ b/kms.tf
@@ -27,12 +27,12 @@ data "aws_iam_policy_document" "kms" {
     condition {
       test     = "ArnLike"
       variable = "kms:EncryptionContext:aws:logs:arn"
-      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.account.account_id}:log-group:/aws/eks/${var.cluster_name}/cluster"]
+      values   = ["arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.account.account_id}:log-group:/aws/eks/${var.cluster_name}/cluster"]
     }
 
     principals {
       type        = "Service"
-      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+      identifiers = ["logs.${data.aws_region.current.region}.amazonaws.com"]
     }
   }
 }

--- a/modules/identity/versions.tf
+++ b/modules/identity/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/secrets.tf
+++ b/secrets.tf
@@ -25,7 +25,7 @@ resource "aws_secretsmanager_secret" "this" {
   recovery_window_in_days = 0 # Force instant deletion
 
   dynamic "replica" {
-    for_each = setsubtract(local.replica_regions, [data.aws_region.current.name])
+    for_each = setsubtract(local.replica_regions, [data.aws_region.current.region])
     content {
       region = replica.value
     }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.5"
+      version = ">= 6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
hotfix. Removes legacy way of referencing region. 
<img width="635" height="104" alt="Screenshot 2025-08-11 at 17 11 46" src="https://github.com/user-attachments/assets/2502472d-d3cd-4fc1-88a6-0305c0aaa59d" />
should not change any behavior in tf, 
[link](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region#name-1)


[before](https://tfe.worldcoin.dev/app/TFH/workspaces/internal-tools-eu-central-1/runs/run-MvqUcCJ6o1bnfVoL) 77
[after](https://tfe.worldcoin.dev/app/TFH/workspaces/internal-tools-eu-central-1/runs/run-GdqM3z7W9MpVzsJj) 61

[before](https://tfe.worldcoin.dev/app/TFH/workspaces/internal-tools-us-east-1/runs/run-CG7ZXUp93d5oqCVD) 69
[after](https://tfe.worldcoin.dev/app/TFH/workspaces/internal-tools-us-east-1/runs/run-YPk6x6bu3bHfyGG6) 53