### PR TITLE
Update workflow `terraform module update` to use runner ubuntu-latest

### DIFF
--- a/.github/workflows/update-terraform-modules.yml
+++ b/.github/workflows/update-terraform-modules.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   update-deployment:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
-    runs-on: arc-medium-arm64-runner
+    runs-on: ubuntu-latest
 
     steps:
       - name: Validate version format


### PR DESCRIPTION
This repository is public, and should use github runners.