### PR TITLE
INFRA-5113: Update EKS Node Group configuration to resolve DNS issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,9 +425,9 @@ To remove the cluster you have to:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.5 |
-| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 4.10 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 4.10 |
 | <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.3 |
@@ -438,7 +438,7 @@ To remove the cluster you have to:
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.5 |
-| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | ~> 4.10 |
+| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | >= 4.10 |
 | <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.3 |
@@ -448,16 +448,15 @@ To remove the cluster you have to:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alb"></a> [alb](#module\_alb) | git@github.com:worldcoin/terraform-aws-alb.git | v0.17.0 |
+| <a name="module_alb"></a> [alb](#module\_alb) | git@github.com:worldcoin/terraform-aws-alb.git | v0.19.0 |
 | <a name="module_datadog_monitoring"></a> [datadog\_monitoring](#module\_datadog\_monitoring) | git@github.com:worldcoin/terraform-datadog-kubernetes | v1.2.2 |
-| <a name="module_nlb"></a> [nlb](#module\_nlb) | git@github.com:worldcoin/terraform-aws-nlb.git | v0.7.0 |
+| <a name="module_nlb"></a> [nlb](#module\_nlb) | git@github.com:worldcoin/terraform-aws-nlb.git | v1.1.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [aws_autoscaling_group.enclave](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
-| [aws_autoscaling_group.static](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_autoscaling_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_cloudwatch_event_rule.spot_aws_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_rule.spot_aws_health](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
@@ -477,6 +476,7 @@ To remove the cluster you have to:
 | [aws_eks_addon.snapshot_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_eks_addon.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster) | resource |
+| [aws_eks_node_group.al2023](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group) | resource |
 | [aws_eks_pod_identity_association.ebs_csi_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_eks_pod_identity_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_iam_instance_profile.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
@@ -500,8 +500,8 @@ To remove the cluster you have to:
 | [aws_iam_role_policy_attachment.ebs_csi_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_launch_template.al2023](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_launch_template.enclave](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
-| [aws_launch_template.static](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
@@ -512,6 +512,8 @@ To remove the cluster you have to:
 | [aws_security_group_rule.additional_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.cluster_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.cluster_from_node_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.node_allow_vpc_dns_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.node_allow_vpc_dns_udp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.node_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.node_from_alb_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.node_from_cluster_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -557,7 +559,8 @@ To remove the cluster you have to:
 | [aws_iam_policy_document.node_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.spot_notification_sqs_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
-| [aws_ssm_parameter.ami_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.al2023_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_vpc.cluster_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 | [cloudflare_zone.worldcoin_dev](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/data-sources/zone) | data source |
 | [datadog_synthetics_locations.locations](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/data-sources/synthetics_locations) | data source |
 | [tls_certificate.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
@@ -576,15 +579,21 @@ To remove the cluster you have to:
 | <a name="input_alb_logs_bucket_id"></a> [alb\_logs\_bucket\_id](#input\_alb\_logs\_bucket\_id) | The ID of the S3 bucket to store logs in for ALB. | `string` | n/a | yes |
 | <a name="input_argocd_role_arn"></a> [argocd\_role\_arn](#input\_argocd\_role\_arn) | The ARN of the remote ArgoCD role used to assume eks-cluster role | `string` | `null` | no |
 | <a name="input_authentication_mode"></a> [authentication\_mode](#input\_authentication\_mode) | The authentication mode for the cluster. Valid values are `CONFIG_MAP`, `API` or `API_AND_CONFIG_MAP` | `string` | `"API_AND_CONFIG_MAP"` | no |
-| <a name="input_cluster_endpoint_public_access"></a> [cluster\_endpoint\_public\_access](#input\_cluster\_endpoint\_public\_access) | Indicates whether or not the Amazon EKS public API server endpoint is enabled | `bool` | `true` | no |
+| <a name="input_aws_autoscaling_group_enabled"></a> [aws\_autoscaling\_group\_enabled](#input\_aws\_autoscaling\_group\_enabled) | Whether to enable AWS Autoscaling group | `bool` | `true` | no |
+| <a name="input_aws_load_balancer_iam_role_enabled"></a> [aws\_load\_balancer\_iam\_role\_enabled](#input\_aws\_load\_balancer\_iam\_role\_enabled) | Whether to enable the IAM role for the AWS Load Balancer | `bool` | `true` | no |
+| <a name="input_cluster_endpoint_public_access"></a> [cluster\_endpoint\_public\_access](#input\_cluster\_endpoint\_public\_access) | Indicates whether or not the Amazon EKS public API server endpoint is enabled | `bool` | `false` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster. Has to be unique per region per account. | `string` | n/a | yes |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The Kubernetes version to use for the cluster. | `string` | `"1.32"` | no |
 | <a name="input_coredns_max_replicas"></a> [coredns\_max\_replicas](#input\_coredns\_max\_replicas) | Maximum number of replicas for CoreDNS | `number` | `10` | no |
 | <a name="input_coredns_min_replicas"></a> [coredns\_min\_replicas](#input\_coredns\_min\_replicas) | Minimum number of replicas for CoreDNS | `number` | `2` | no |
 | <a name="input_datadog_api_key"></a> [datadog\_api\_key](#input\_datadog\_api\_key) | Datadog API key. Stored in kube-system namespace as a secret. | `string` | n/a | yes |
+| <a name="input_deploy_desired_vs_status_critical"></a> [deploy\_desired\_vs\_status\_critical](#input\_deploy\_desired\_vs\_status\_critical) | Threshold for critical for Desired pods vs current pods (Deployments) | `number` | `10` | no |
+| <a name="input_deploy_desired_vs_status_evaluation_period"></a> [deploy\_desired\_vs\_status\_evaluation\_period](#input\_deploy\_desired\_vs\_status\_evaluation\_period) | Evaluation period for Desired pods vs current pods (Deployments) | `string` | `"last_15m"` | no |
+| <a name="input_deploy_desired_vs_status_warning"></a> [deploy\_desired\_vs\_status\_warning](#input\_deploy\_desired\_vs\_status\_warning) | Threshold for warning for Desired pods vs current pods (Deployments) | `number` | `1` | no |
 | <a name="input_dockerhub_pull_through_cache_repositories_arn"></a> [dockerhub\_pull\_through\_cache\_repositories\_arn](#input\_dockerhub\_pull\_through\_cache\_repositories\_arn) | The ARN of the repositories to allow the EKS node group to pull images from the DockerHub pull-through cache. | `string` | `"arn:aws:ecr:us-east-1:507152310572:repository/docker-cache/*"` | no |
 | <a name="input_drop_invalid_header_fields"></a> [drop\_invalid\_header\_fields](#input\_drop\_invalid\_header\_fields) | Drop invalid header fields | `bool` | `false` | no |
 | <a name="input_efs_csi_driver_enabled"></a> [efs\_csi\_driver\_enabled](#input\_efs\_csi\_driver\_enabled) | Whether to enable the EFS CSI driver (IAM Role & StorageClass). | `bool` | `false` | no |
+| <a name="input_eks_node_group"></a> [eks\_node\_group](#input\_eks\_node\_group) | Configuration for EKS node group | <pre>object({<br>    arch  = string<br>    types = list(string)<br>    disk  = optional(number, 100)<br>    dns   = optional(string, "172.20.0.10")<br>  })</pre> | `null` | no |
 | <a name="input_enclaves"></a> [enclaves](#input\_enclaves) | Enabling Nitro Enclaves for the cluster | `bool` | `false` | no |
 | <a name="input_enclaves_autoscaling_group"></a> [enclaves\_autoscaling\_group](#input\_enclaves\_autoscaling\_group) | Configuration for Nitro Enclaves autoscaling group | <pre>object({<br>    size = number<br>  })</pre> | <pre>{<br>  "size": 2<br>}</pre> | no |
 | <a name="input_enclaves_instance_type"></a> [enclaves\_instance\_type](#input\_enclaves\_instance\_type) | Instance type for Nitro Enclaves | `string` | `"m7a.2xlarge"` | no |
@@ -601,7 +610,6 @@ To remove the cluster you have to:
 | <a name="input_internal_tls_listener_version"></a> [internal\_tls\_listener\_version](#input\_internal\_tls\_listener\_version) | The version of the TLS listener to use for internal NLB. | `string` | `"1.3"` | no |
 | <a name="input_kube_ops_enabled"></a> [kube\_ops\_enabled](#input\_kube\_ops\_enabled) | Whether to create a role and association for kube-ops | `bool` | `true` | no |
 | <a name="input_kubelet_extra_args"></a> [kubelet\_extra\_args](#input\_kubelet\_extra\_args) | kubelet extra args to pass to the node group | `string` | `"--register-with-taints=critical:NoExecute"` | no |
-| <a name="input_kubelet_extra_args_static_autoscaling_group"></a> [kubelet\_extra\_args\_static\_autoscaling\_group](#input\_kubelet\_extra\_args\_static\_autoscaling\_group) | kubelet extra args to pass to the static node group | `string` | `""` | no |
 | <a name="input_kubernetes_provider_enabled"></a> [kubernetes\_provider\_enabled](#input\_kubernetes\_provider\_enabled) | Whether to create a Kubernetes provider for the cluster. Use as a prerequisite to cluster removal. | `bool` | `true` | no |
 | <a name="input_memory_limits_low_perc_enabled"></a> [memory\_limits\_low\_perc\_enabled](#input\_memory\_limits\_low\_perc\_enabled) | Enable memory limits low percentage alert | `bool` | `false` | no |
 | <a name="input_monitoring_enabled"></a> [monitoring\_enabled](#input\_monitoring\_enabled) | Whether to enable monitoring (Datadog). | `bool` | `true` | no |
@@ -617,10 +625,13 @@ To remove the cluster you have to:
 | <a name="input_static_autoscaling_group"></a> [static\_autoscaling\_group](#input\_static\_autoscaling\_group) | Configuration for static autoscaling group | <pre>object({<br>    size = number<br>    arch = optional(string, null)<br>    type = string<br>  })</pre> | `null` | no |
 | <a name="input_storage_class"></a> [storage\_class](#input\_storage\_class) | Configuration for the storage class that defines how volumes are allocated in Kubernetes. | <pre>object({<br>    volume_binding_mode    = optional(string, "WaitForFirstConsumer")<br>    allow_volume_expansion = optional(bool, true)<br>  })</pre> | <pre>{<br>  "allow_volume_expansion": true,<br>  "volume_binding_mode": "WaitForFirstConsumer"<br>}</pre> | no |
 | <a name="input_tfe_cidr"></a> [tfe\_cidr](#input\_tfe\_cidr) | Terraform Enterprise CIDR block | `string` | `"10.52.160.0/20"` | no |
-| <a name="input_traefik_cert_arn"></a> [traefik\_cert\_arn](#input\_traefik\_cert\_arn) | The ARN of the certificate to use for Traefik. | `string` | n/a | yes |
+| <a name="input_traefik_cert_arn"></a> [traefik\_cert\_arn](#input\_traefik\_cert\_arn) | The ARN of the certificate to use for Traefik. | `string` | `null` | no |
 | <a name="input_traefik_nlb_service_ports"></a> [traefik\_nlb\_service\_ports](#input\_traefik\_nlb\_service\_ports) | List of additional ports for treafik k8s service | <pre>list(object({<br>    name        = string<br>    port        = number<br>    target_port = string<br>    protocol    = string<br>  }))</pre> | `[]` | no |
 | <a name="input_use_private_subnets_for_internal_nlb"></a> [use\_private\_subnets\_for\_internal\_nlb](#input\_use\_private\_subnets\_for\_internal\_nlb) | Set to `true` if you want to use private subnets for internal NLB | `bool` | `false` | no |
+| <a name="input_vpc_cni_enable_pod_eni"></a> [vpc\_cni\_enable\_pod\_eni](#input\_vpc\_cni\_enable\_pod\_eni) | Enable pod ENI support | `bool` | `true` | no |
 | <a name="input_vpc_cni_enable_prefix_delegation"></a> [vpc\_cni\_enable\_prefix\_delegation](#input\_vpc\_cni\_enable\_prefix\_delegation) | Enable prefix delegation for IPv6, allocate IPs in /28 blocks (instead of all at once) | `bool` | `false` | no |
+| <a name="input_vpc_cni_external_snat"></a> [vpc\_cni\_external\_snat](#input\_vpc\_cni\_external\_snat) | Needed to enable cross-vpc pod-to-pod communication - see: https://github.com/aws/amazon-vpc-cni-k8s?tab=readme-ov-file#aws_vpc_k8s_cni_externalsnat | `string` | `false` | no |
+| <a name="input_vpc_cni_pod_security_group_enforcing_mode"></a> [vpc\_cni\_pod\_security\_group\_enforcing\_mode](#input\_vpc\_cni\_pod\_security\_group\_enforcing\_mode) | Set pod security group enforcing mode | `string` | `"standard"` | no |
 | <a name="input_vpc_cni_version_override"></a> [vpc\_cni\_version\_override](#input\_vpc\_cni\_version\_override) | The version of the VPC CNI plugin to use. If not specified, the default version for the cluster version will be used. | `string` | `""` | no |
 | <a name="input_vpc_cni_warm_eni_target"></a> [vpc\_cni\_warm\_eni\_target](#input\_vpc\_cni\_warm\_eni\_target) | Number of ENIs to keep warm for each node to speed up pod scheduling | `string` | `"1"` | no |
 | <a name="input_vpc_cni_warm_ip_target"></a> [vpc\_cni\_warm\_ip\_target](#input\_vpc\_cni\_warm\_ip\_target) | Number of IPs to keep warm for each node to speed up pod scheduling | `string` | `"8"` | no |

--- a/eks-node-group.tf
+++ b/eks-node-group.tf
@@ -16,9 +16,9 @@ resource "aws_launch_template" "al2023" {
 
   name_prefix = local.al2023_name_prefix
 
-  image_id               = data.aws_ssm_parameter.al2023_ami[0].value
-  vpc_security_group_ids = [aws_security_group.node.id]
-  ebs_optimized          = true
+  image_id                             = data.aws_ssm_parameter.al2023_ami[0].value
+  vpc_security_group_ids               = [aws_security_group.node.id]
+  ebs_optimized                        = true
 
   block_device_mappings {
     device_name = "/dev/xvda"
@@ -49,8 +49,7 @@ resource "aws_launch_template" "al2023" {
       cluster_name        = aws_eks_cluster.this.name
       cluster_endpoint    = aws_eks_cluster.this.endpoint
       cluster_certificate = aws_eks_cluster.this.certificate_authority[0].data
-      cluster_cidr        = data.aws_vpc.cluster_vpc.cidr_block
-      cluster_dns         = "172.20.0.10"
+      cluster_cidr     = data.aws_vpc.cluster_vpc.cidr_block
     })
   )
 }

--- a/eks-node-group.tf
+++ b/eks-node-group.tf
@@ -46,10 +46,8 @@ resource "aws_launch_template" "al2023" {
 
   user_data = base64encode(
     templatefile("${path.module}/templates/userdata-al2023.tpl", {
-      cluster_name        = aws_eks_cluster.this.name
-      cluster_endpoint    = aws_eks_cluster.this.endpoint
-      cluster_certificate = aws_eks_cluster.this.certificate_authority[0].data
-      cluster_cidr     = data.aws_vpc.cluster_vpc.cidr_block
+      cluster_name = aws_eks_cluster.this.name
+      cluster_cidr = data.aws_vpc.cluster_vpc.cidr_block
     })
   )
 }

--- a/eks-node-group.tf
+++ b/eks-node-group.tf
@@ -50,7 +50,7 @@ resource "aws_launch_template" "al2023" {
       cluster_endpoint    = aws_eks_cluster.this.endpoint
       cluster_certificate = aws_eks_cluster.this.certificate_authority[0].data
       cluster_cidr        = data.aws_vpc.cluster_vpc.cidr_block
-      cluster_dns         = "172.20.0.10"
+      cluster_dns         = var.eks_node_group.dns
     })
   )
 }

--- a/eks-node-group.tf
+++ b/eks-node-group.tf
@@ -49,7 +49,6 @@ resource "aws_launch_template" "al2023" {
       cluster_name        = aws_eks_cluster.this.name
       cluster_endpoint    = aws_eks_cluster.this.endpoint
       cluster_certificate = aws_eks_cluster.this.certificate_authority[0].data
-      cluster_cidr     = data.aws_vpc.cluster_vpc.cidr_block
     })
   )
 }

--- a/eks-node-group.tf
+++ b/eks-node-group.tf
@@ -49,6 +49,7 @@ resource "aws_launch_template" "al2023" {
       cluster_name        = aws_eks_cluster.this.name
       cluster_endpoint    = aws_eks_cluster.this.endpoint
       cluster_certificate = aws_eks_cluster.this.certificate_authority[0].data
+      cluster_cidr     = data.aws_vpc.cluster_vpc.cidr_block
     })
   )
 }

--- a/eks-node-group.tf
+++ b/eks-node-group.tf
@@ -16,9 +16,9 @@ resource "aws_launch_template" "al2023" {
 
   name_prefix = local.al2023_name_prefix
 
-  image_id                             = data.aws_ssm_parameter.al2023_ami[0].value
-  vpc_security_group_ids               = [aws_security_group.node.id]
-  ebs_optimized                        = true
+  image_id               = data.aws_ssm_parameter.al2023_ami[0].value
+  vpc_security_group_ids = [aws_security_group.node.id]
+  ebs_optimized          = true
 
   block_device_mappings {
     device_name = "/dev/xvda"
@@ -49,7 +49,8 @@ resource "aws_launch_template" "al2023" {
       cluster_name        = aws_eks_cluster.this.name
       cluster_endpoint    = aws_eks_cluster.this.endpoint
       cluster_certificate = aws_eks_cluster.this.certificate_authority[0].data
-      cluster_cidr     = data.aws_vpc.cluster_vpc.cidr_block
+      cluster_cidr        = data.aws_vpc.cluster_vpc.cidr_block
+      cluster_dns         = "172.20.0.10"
     })
   )
 }

--- a/eks-node-group.tf
+++ b/eks-node-group.tf
@@ -46,8 +46,10 @@ resource "aws_launch_template" "al2023" {
 
   user_data = base64encode(
     templatefile("${path.module}/templates/userdata-al2023.tpl", {
-      cluster_name = aws_eks_cluster.this.name
-      cluster_cidr = data.aws_vpc.cluster_vpc.cidr_block
+      cluster_name        = aws_eks_cluster.this.name
+      cluster_endpoint    = aws_eks_cluster.this.endpoint
+      cluster_certificate = aws_eks_cluster.this.certificate_authority[0].data
+      cluster_cidr     = data.aws_vpc.cluster_vpc.cidr_block
     })
   )
 }

--- a/templates/userdata-al2023.tpl
+++ b/templates/userdata-al2023.tpl
@@ -7,9 +7,5 @@ spec:
     apiServerEndpoint: ${cluster_endpoint}
     certificateAuthority: ${cluster_certificate}
     cidr: ${cluster_cidr}
-  kubelet:
-    config:
-      clusterDNS:
-        - "${cluster_dns}"
 userdata:
     type: EKS_NODEADM

--- a/templates/userdata-al2023.tpl
+++ b/templates/userdata-al2023.tpl
@@ -7,5 +7,3 @@ spec:
     apiServerEndpoint: ${cluster_endpoint}
     certificateAuthority: ${cluster_certificate}
     cidr: ${cluster_cidr}
-userdata:
-    type: EKS_NODEADM

--- a/templates/userdata-al2023.tpl
+++ b/templates/userdata-al2023.tpl
@@ -4,6 +4,8 @@ kind: NodeConfig
 spec:
   cluster:
     name: ${cluster_name}
+    apiServerEndpoint: ${cluster_endpoint}
+    certificateAuthority: ${cluster_certificate}
     cidr: ${cluster_cidr}
 userdata:
     type: EKS_NODEADM

--- a/templates/userdata-al2023.tpl
+++ b/templates/userdata-al2023.tpl
@@ -7,5 +7,9 @@ spec:
     apiServerEndpoint: ${cluster_endpoint}
     certificateAuthority: ${cluster_certificate}
     cidr: ${cluster_cidr}
+  kubelet:
+    config:
+      clusterDNS:
+        - "${cluster_dns}"
 userdata:
     type: EKS_NODEADM

--- a/templates/userdata-al2023.tpl
+++ b/templates/userdata-al2023.tpl
@@ -4,8 +4,6 @@ kind: NodeConfig
 spec:
   cluster:
     name: ${cluster_name}
-    apiServerEndpoint: ${cluster_endpoint}
-    certificateAuthority: ${cluster_certificate}
     cidr: ${cluster_cidr}
 userdata:
     type: EKS_NODEADM

--- a/templates/userdata-al2023.tpl
+++ b/templates/userdata-al2023.tpl
@@ -6,3 +6,6 @@ spec:
     name: ${cluster_name}
     apiServerEndpoint: ${cluster_endpoint}
     certificateAuthority: ${cluster_certificate}
+    cidr: ${cluster_cidr}
+userdata:
+    type: EKS_NODEADM

--- a/templates/userdata-al2023.tpl
+++ b/templates/userdata-al2023.tpl
@@ -11,3 +11,5 @@ spec:
     config:
       clusterDNS:
         - "${cluster_dns}"
+userdata:
+    type: EKS_NODEADM

--- a/templates/userdata-al2023.tpl
+++ b/templates/userdata-al2023.tpl
@@ -7,3 +7,7 @@ spec:
     apiServerEndpoint: ${cluster_endpoint}
     certificateAuthority: ${cluster_certificate}
     cidr: ${cluster_cidr}
+  kubelet:
+    config:
+      clusterDNS:
+        - "${cluster_dns}"

--- a/templates/userdata-al2023.tpl
+++ b/templates/userdata-al2023.tpl
@@ -6,6 +6,3 @@ spec:
     name: ${cluster_name}
     apiServerEndpoint: ${cluster_endpoint}
     certificateAuthority: ${cluster_certificate}
-    cidr: ${cluster_cidr}
-userdata:
-    type: EKS_NODEADM

--- a/variables.tf
+++ b/variables.tf
@@ -663,6 +663,7 @@ variable "eks_node_group" {
     arch  = string
     types = list(string)
     disk  = optional(number, 100)
+    dns   = optional(string, "172.20.0.10")
   })
 
   default = null


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-5113/fix-dns-on-smpcv2-stage-clusters
Tested (yes/no): yes https://github.com/worldcoin/infrastructure/pull/24333
```sh
~ # ping go.dev
PING go.dev (216.239.38.21) 56(84) bytes of data.
64 bytes from any-in-2615.1e100.net (216.239.38.21): icmp_seq=1 ttl=115 time=3.78 ms
64 bytes from any-in-2615.1e100.net (216.239.38.21): icmp_seq=2 ttl=115 time=1.80 ms
64 bytes from any-in-2615.1e100.net (216.239.38.21): icmp_seq=3 ttl=115 time=1.82 ms
64 bytes from any-in-2615.1e100.net (216.239.38.21): icmp_seq=4 ttl=115 time=1.84 ms
64 bytes from any-in-2615.1e100.net (216.239.38.21): icmp_seq=5 ttl=115 time=1.83 ms
^C
--- go.dev ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 4007ms
rtt min/avg/max/mdev = 1.797/2.213/3.784/0.785 ms



~ # grep nameserver /etc/resolv.conf
nameserver 172.20.0.10



I> kubectl describe pod netshoot | grep ^Node
Node:             ip-10-0-161-247.ec2.internal/10.0.161.247
Node-Selectors:              eks.amazonaws.com/nodegroup=eks-node-al2023-tools-dev-us-east-1



[root@ip-10-0-161-247 ~]# jq .clusterDNS /etc/kubernetes/kubelet/config.json.d/40-nodeadm.conf
[
  "172.20.0.10"
]
```

Description/Why:

**Problem:**
Nodes provisioned within the `eks_node_group` were failing to resolve DNS. Investigation revealed that the `kubelet` was configured with an incorrect `clusterDNS` IP (`10.0.160.10`), while the correct service IP was `172.20.0.10`

**Root Cause:**
The `nodeadm` bootstrap tool on AL2023 nodes defaults to assuming the `kube-dns` service is located at the `.10` IP address of the cluster's service CIDR. In our environment, the `kube-dns` service has a different, non-default IP. This mismatch caused the automatic discovery to fail, leading to DNS resolution errors within pods on these nodes. Nodes managed by `karpenter` were unaffected

**Solution:**
By providing the correct `clusterDNS` IP via the `NodeConfig`, we override the faulty default behavior of `nodeadm`. This ensures that `kubelet` is configured with the correct DNS server