### PR TITLE
Disable nlb deletion protection

### DIFF
--- a/kubernetes-traefik-internal.tf
+++ b/kubernetes-traefik-internal.tf
@@ -19,7 +19,7 @@ resource "kubernetes_service" "traefik_nlb" {
       "service.beta.kubernetes.io/aws-load-balancer-ssl-ports"                           = "443"
       "service.beta.kubernetes.io/aws-load-balancer-type"                                = "external"
       "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy"              = module.nlb[each.key].ssl_policy
-      "service.beta.kubernetes.io/aws-load-balancer-attributes"                          = "deletion_protection.enabled=true"
+      "service.beta.kubernetes.io/aws-load-balancer-attributes"                          = "deletion_protection.enabled=false"
       "service.beta.kubernetes.io/aws-load-balancer-security-groups"                     = module.nlb[each.key].sg_nlb_id
       "service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules" = "true"
       "CreatedBy"                                                                        = "terraform"


### PR DESCRIPTION
Disable nlb deletion protection

Flapping caused by https://github.com/worldcoin/terraform-aws-nlb/pull/37
