### PR TITLE
INFRA-5190(templates/al2023): Configure `eks_nodes_group` to register with taints

### DIFF
--- a/templates/userdata-al2023.tpl
+++ b/templates/userdata-al2023.tpl
@@ -11,5 +11,9 @@ spec:
     config:
       clusterDNS:
         - "${cluster_dns}"
+      registerWithTaints:
+        - key: "critical"
+          value: "true"
+          effect: "NoExecute"
 userdata:
     type: EKS_NODEADM


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-5190/al2023-nodes-from-asg-lack-taint
Tested (yes/no): yes
Description/Why:

> We need this taint because when something bigger will start on these "first" nodes, it can prevent karpenter from starting. In that scenario cluster autoscaling will stop working.