### PR TITLE
INFRA-5223(kubernetes): Add lifecycle ignore changes for `load_balancer_class`

### DIFF
--- a/kubernetes-traefik-internal.tf
+++ b/kubernetes-traefik-internal.tf
@@ -60,6 +60,10 @@ resource "kubernetes_service" "traefik_nlb" {
 
     type = "LoadBalancer"
   }
+
+  lifecycle {
+    ignore_changes = [spec[0].load_balancer_class]
+  }
 }
 
 module "nlb" {


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-5223/investigate-why-terraform-wants-to-recreate-the-k8s-service-traefik
Tested (yes/no): yes https://github.com/worldcoin/infrastructure/pull/25317
Description/Why: newly created `nlb` require this field set to `service.k8s.aws/nlb`, while older ones require an empty string... so it's best to ignore this field

