### PR TITLE
make aws template use known version if possible

### DIFF
--- a/eks-node-group.tf
+++ b/eks-node-group.tf
@@ -19,6 +19,7 @@ resource "aws_launch_template" "al2023" {
   image_id               = data.aws_ssm_parameter.al2023_ami[0].value
   vpc_security_group_ids = [aws_security_group.node.id]
   ebs_optimized          = true
+  update_default_version = true
 
   block_device_mappings {
     device_name = "/dev/xvda"
@@ -79,7 +80,7 @@ resource "aws_eks_node_group" "al2023" {
 
   launch_template {
     id      = aws_launch_template.al2023[0].id
-    version = aws_launch_template.al2023[0].latest_version != null ? aws_launch_template.al2023[0].latest_version : "$Latest"
+    version = try(aws_launch_template.al2023[0].latest_version, "$Latest")
   }
 
   tags = {

--- a/eks-node-group.tf
+++ b/eks-node-group.tf
@@ -79,7 +79,7 @@ resource "aws_eks_node_group" "al2023" {
 
   launch_template {
     id      = aws_launch_template.al2023[0].id
-    version = "$Latest"
+    version = aws_launch_template.al2023[0].latest_version != null ? aws_launch_template.al2023[0].latest_version : "$Latest"
   }
 
   tags = {


### PR DESCRIPTION
Requestor/Issue: @orlra
Tested (yes/no): yes
Description/Why:
this line flaps on most TF envs. we likely want to use known number so TF is not complaining as much, when possible.
this clones solution of [BM](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/modules/eks-managed-node-group/main.tf#L444C67-L444C128) which should stop flapping. 