### PR TITLE
INFRA-5193: update enclave nodes taints

### DIFF
--- a/templates/userdata-enclaves.sh.tpl
+++ b/templates/userdata-enclaves.sh.tpl
@@ -47,8 +47,8 @@ spec:
       clusterDNS:
         - "${cluster_dns}"
       registerWithTaints:
-        - key: enclave
-          effect: NoExecute
+        - key: nitro
+          effect: NoSchedule
     flags:            # List of kubelet flags
        - --node-labels=aws-nitro-enclaves-k8s-dp=enabled
  


### PR DESCRIPTION
K8S nitro enclave plugin is not able to set custom tolerations but uses `nitro:NoSchedule` as default. This PR change taints for eks nodes for enclave to be alignet with k8s plugin.