### PR TITLE
INFRA-5240: Upgrade karpenter to version 1.6.2

### DIFF
--- a/iam-karpenter.tf
+++ b/iam-karpenter.tf
@@ -42,7 +42,8 @@ data "aws_iam_policy_document" "karpenter" {
       "ec2:CreateLaunchTemplate",
       "ec2:CreateFleet",
       "ec2:DescribeSpotPriceHistory",
-      "pricing:GetProducts"
+      "pricing:GetProducts",
+      "ec2:DescribeCapacityReservations"
     ]
   }
   statement {


### PR DESCRIPTION
Requestor/Issue: INFRA-5240
Tested (yes/no): no
Description/Why: Karpenter 1.6.2 require to have additional configuration with information about capacity reservation, after add it it's require to have access to verify if that capacity reservation exists. This PR add access to list capacity reservation for karpenter.