### PR TITLE
INFRA-5346: cluster autoscaler works with enclave node groups

### DIFF
--- a/node-groups-enclave.tf
+++ b/node-groups-enclave.tf
@@ -63,6 +63,10 @@ resource "aws_autoscaling_group" "enclave" {
   min_size            = var.enclaves_autoscaling_group.min_size
   max_size            = var.enclaves_autoscaling_group.max_size
 
+  lifecycle {
+    ignore_changes = [desired_capacity]
+  }
+
   mixed_instances_policy {
     instances_distribution {
       on_demand_base_capacity = var.enclaves_autoscaling_group.size


### PR DESCRIPTION
Requestor/Issue: INFRA-5346
Tested (yes/no): yes
Description/Why: this configuration ignore changes for desired_capacity for enclave node group where cluster autoscaler works and can set different desired_capacity than set by terraform