### PR TITLE
INFRA-5344: The default kubernetes version set to v1.33.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "region" {
 variable "cluster_version" {
   description = "The Kubernetes version to use for the cluster."
   type        = string
-  default     = "1.32"
+  default     = "1.33"
 }
 
 variable "vpc_config" {


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-5344/set-v133-as-the-default-kubernetes-version
Tested (yes/no): N/A
Description/Why: Updating the default kubernetes version in terraform to align to the one that runs all of our clusters already.