### PR TITLE
feat: Support enclave tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Example with enclave tracks for running multiple versions simultaneously:
 
 ```terraform
 module "eks" {
-  source = "git@github.com:worldcoin/terraform-aws-eks?ref=v7.6.0"
+  source = "git@github.com:worldcoin/terraform-aws-eks?ref=v7.11.0"
   
   # ... other configuration ...
   

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ module "eks" {
   
   # Multiple enclave tracks for different versions
   enclave_tracks = {
-    stable = {
+    v1 = {
       autoscaling_group = {
         size     = 3  # Spreads across AZs
         min_size = 3
@@ -316,7 +316,7 @@ module "eks" {
       memory_allocation = "8192"
     }
     
-    canary = {
+    v2 = {
       autoscaling_group = {
         size     = 1
         min_size = 0

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Example with basic enclave support:
 
 ```terraform
 module "eks" {
-  source = "git@github.com:worldcoin/terraform-aws-eks?ref=v7.6.0"
+  source = "git@github.com:worldcoin/terraform-aws-eks?ref=v7.11.0"
   
   # ... other configuration ...
   

--- a/node-groups-enclave-tracks.tf
+++ b/node-groups-enclave-tracks.tf
@@ -1,0 +1,143 @@
+# Enclave tracks for multi-version deployments
+# This creates additional node groups for running multiple enclave versions simultaneously
+
+resource "aws_launch_template" "enclave_track" {
+  for_each = var.enclave_tracks
+
+  name_prefix = "eks-node-enclaves-${each.key}-${var.cluster_name}-"
+
+  image_id                             = data.aws_ssm_parameter.al2023_ami[try(var.eks_node_group.arch, "amd64")].value
+  instance_type                        = coalesce(each.value.instance_type, var.enclaves_instance_type)
+  vpc_security_group_ids               = [aws_security_group.node.id]
+  ebs_optimized                        = true
+  instance_initiated_shutdown_behavior = "terminate"
+
+  enclave_options {
+    enabled = true
+  }
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.node.arn
+  }
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+
+    ebs {
+      volume_size = 100
+    }
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = var.http_put_response_hop_limit
+    instance_metadata_tags      = "enabled"
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+
+    tags = {
+      Name              = "eks-node-enclaves-${each.key}-${var.cluster_name}"
+      KubernetesCluster = var.cluster_name
+      EnclaveTrack      = each.key
+    }
+  }
+
+  user_data = base64encode(
+    templatefile("${path.module}/templates/userdata-enclave-track.sh.tpl", {
+      cluster_name              = aws_eks_cluster.this.name
+      cluster_endpoint          = aws_eks_cluster.this.endpoint
+      cluster_certificate       = aws_eks_cluster.this.certificate_authority[0].data
+      cluster_cidr              = data.aws_vpc.cluster_vpc.cidr_block
+      cluster_dns               = var.eks_node_group.dns
+      enclave_track             = each.key
+      enclave_cpu_allocation    = coalesce(each.value.cpu_allocation, var.enclaves_cpu_allocation)
+      enclave_memory_allocation = coalesce(each.value.memory_allocation, var.enclaves_memory_allocation)
+    })
+  )
+}
+
+resource "aws_autoscaling_group" "enclave_track" {
+  for_each = var.enclave_tracks
+
+  name                = "eks-node-enclaves-${each.key}-${var.cluster_name}"
+  vpc_zone_identifier = var.vpc_config.private_subnets
+  desired_capacity    = each.value.autoscaling_group.size
+  min_size            = each.value.autoscaling_group.min_size
+  max_size            = each.value.autoscaling_group.max_size
+
+  lifecycle {
+    ignore_changes = [desired_capacity]
+  }
+
+  mixed_instances_policy {
+    instances_distribution {
+      on_demand_base_capacity = each.value.autoscaling_group.size
+    }
+
+    launch_template {
+      launch_template_specification {
+        launch_template_id = aws_launch_template.enclave_track[each.key].id
+        version            = "$Latest"
+      }
+    }
+  }
+
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/enabled"
+    value               = "true"
+    propagate_at_launch = false
+  }
+
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/${var.cluster_name}"
+    value               = "owned"
+    propagate_at_launch = false
+  }
+
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/taint/enclave"
+    value               = "NoExecute"
+    propagate_at_launch = false
+  }
+
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/taint/enclave.tools/track"
+    value               = "${each.key}:NoSchedule"
+    propagate_at_launch = false
+  }
+
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/intent"
+    value               = "enclave"
+    propagate_at_launch = false
+  }
+
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/label/enclave.tools/track"
+    value               = each.key
+    propagate_at_launch = false
+  }
+
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/resources/aws.ec2.nitro/nitro_enclaves"
+    value               = "1"
+    propagate_at_launch = false
+  }
+
+  tag {
+    key                 = "k8s.io/cluster-autoscaler/node-template/resources/hugepages-1Gi"
+    value               = "1Gi"
+    propagate_at_launch = false
+  }
+
+  instance_refresh {
+    strategy = "Rolling"
+    preferences {
+      min_healthy_percentage = 50
+      auto_rollback          = true
+    }
+  }
+}

--- a/templates/userdata-enclave-track.sh.tpl
+++ b/templates/userdata-enclave-track.sh.tpl
@@ -1,0 +1,58 @@
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="==MYBOUNDARY=="
+
+--==MYBOUNDARY==
+Content-Type: text/cloud-config; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="cloud-config.txt"
+
+#cloud-config
+bootcmd:
+ - dnf install aws-nitro-enclaves-cli -y
+
+--==MYBOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
+
+#!/bin/bash
+set -e
+
+# source: https://docs.aws.amazon.com/enclaves/latest/user/kubernetes.html
+readonly NE_ALLOCATOR_SPEC_PATH="/etc/nitro_enclaves/allocator.yaml"
+# Node resources that will be allocated for Nitro Enclaves
+readonly CPU_COUNT=${enclave_cpu_allocation}
+readonly MEMORY_MIB=${enclave_memory_allocation}
+
+# Update enclave's allocator specification: allocator.yaml
+sed -i "s/cpu_count:.*/cpu_count: $CPU_COUNT/g" $NE_ALLOCATOR_SPEC_PATH
+sed -i "s/memory_mib:.*/memory_mib: $MEMORY_MIB/g" $NE_ALLOCATOR_SPEC_PATH
+# Restart the nitro-enclaves-allocator service to take changes effect.
+systemctl restart nitro-enclaves-allocator.service
+echo "NE user data script has finished successfully for track: ${enclave_track}"
+
+--==MYBOUNDARY==
+Content-Type: application/node.eks.aws
+
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: ${cluster_name}
+    apiServerEndpoint: ${cluster_endpoint}
+    certificateAuthority: ${cluster_certificate}
+    cidr: ${cluster_cidr}
+  kubelet:
+    config:
+      clusterDNS:
+        - "${cluster_dns}"
+      registerWithTaints:
+        - key: enclave
+          effect: NoExecute
+        - key: enclave.tools/track
+          value: "${enclave_track}"
+          effect: NoSchedule
+    flags:            # List of kubelet flags
+       - --node-labels=aws-nitro-enclaves-k8s-dp=enabled,intent=enclave,enclave.tools/track=${enclave_track}
+ 
+--==MYBOUNDARY==

--- a/variables.tf
+++ b/variables.tf
@@ -611,6 +611,29 @@ variable "enclaves_memory_allocation" {
   default     = "4096"
 }
 
+variable "enclave_tracks" {
+  description = "Additional enclave tracks for multi-version deployments. Key is used as track identifier."
+  type = map(object({
+    autoscaling_group = optional(object({
+      size     = optional(number, 1)
+      min_size = optional(number, 0)
+      max_size = optional(number, 10)
+    }), {})
+    instance_type     = optional(string)
+    cpu_allocation    = optional(string)
+    memory_allocation = optional(string)
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.enclave_tracks :
+      can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", k)) && length(k) <= 30
+    ])
+    error_message = "Track keys must be valid Kubernetes labels (lowercase alphanumeric, hyphens, max 30 chars)"
+  }
+}
+
 variable "storage_class" {
   description = "Configuration for the storage class that defines how volumes are allocated in Kubernetes."
 


### PR DESCRIPTION
## Motivation
Enable running multiple enclave versions simultaneously in the same EKS cluster for zero-downtime deployments and A/B testing of secure enclaves.

## Problem
- Current module only supports a single enclave version cluster-wide
- No way to gradually roll out new enclave versions
- Risky deployments require full cluster updates

## Solution
Add support for "enclave tracks" - isolated node groups for different enclave versions.

### Changes

**terraform-aws-eks module:**
- ✅ Added `enclave_tracks` variable to `variables.tf`
- ✅ Created `node-groups-enclave-tracks.tf` for track-specific ASGs
- ✅ Added `templates/userdata-enclave-track.sh.tpl` for track-aware nodes
- ✅ Updated README with examples

**Key Features:**
- Each track gets dedicated nodes with labels/taints
- Backwards compatible - existing `enclaves = true` still works
- Multi-AZ spreading via existing `vpc_config.private_subnets`
- Track isolation via `enclave.tools/track=<name>` labels and taints

### Usage Example
```hcl
enclave_tracks = {
  v1 = {
    autoscaling_group = { size = 3 }
    instance_type = "m7a.4xlarge"
  }
  v2 = {
    autoscaling_group = { size = 1 }
    instance_type = "m7a.2xlarge"
  }
}
```

### Impact
- ✅ No breaking changes
- ✅ Optional feature - zero impact if not used
- ✅ Enables gradual rollouts and safer deployments