### PR TITLE
INFRA-6062: Trim region suffix from `cluster_name` in Gateway API LB name prefix

### DIFF
--- a/kubernetes.tf
+++ b/kubernetes.tf
@@ -37,7 +37,8 @@ provider "kubernetes" {
 }
 
 locals {
-  gateway_api_lb_name_prefix = coalesce(var.gateway_api_lb_name_prefix, var.cluster_name)
+  cluster_name_without_region = trimsuffix(var.cluster_name, "-${var.region}")
+  gateway_api_lb_name_prefix  = coalesce(var.gateway_api_lb_name_prefix, local.cluster_name_without_region)
 }
 
 resource "terraform_data" "gateway_api_lb_name_validation" {

--- a/tests/kubernetes-gateway-api.tftest.hcl
+++ b/tests/kubernetes-gateway-api.tftest.hcl
@@ -108,6 +108,38 @@ run "gateway_api_lb_prefix_not_required_when_gateway_disabled" {
 }
 
 # =============================================================================
+# Test: cluster_name with region suffix gets trimmed
+# =============================================================================
+run "gateway_api_lb_prefix_trims_region_suffix" {
+  command = plan
+
+  variables {
+    cluster_name = "my-cluster-us-east-1"
+  }
+
+  assert {
+    condition     = local.gateway_api_lb_name_prefix == "my-cluster"
+    error_message = "gateway_api_lb_name_prefix should trim the -region suffix from cluster_name"
+  }
+}
+
+# =============================================================================
+# Test: cluster_name without region suffix stays unchanged
+# =============================================================================
+run "gateway_api_lb_prefix_no_trim_without_region" {
+  command = plan
+
+  variables {
+    cluster_name = "my-cluster"
+  }
+
+  assert {
+    condition     = local.gateway_api_lb_name_prefix == "my-cluster"
+    error_message = "gateway_api_lb_name_prefix should keep cluster_name unchanged when no region suffix"
+  }
+}
+
+# =============================================================================
 # Test: Long cluster_name + gateway enabled + no prefix → plan must fail
 # =============================================================================
 run "gateway_api_lb_prefix_missing_long_name_fails" {


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-6062/create-gateway-api-albnlb-from-terraform-aws-eks
Tested (yes/no): yes
Description/Why: clusters following the `<name>-<region>` naming convention (e.g. `tools-gatewayapi1-dev-us-east-1`) exceed the 21-character `gateway_api_lb_name_prefix` limit because the region is included in the default prefix. ALB and NLB modules already strip the region, so this aligns behavior. The fix auto-trims the `-<region>` suffix from `cluster_name` before using it as the default `gateway_api_lb_name_prefix`, avoiding the precondition error without requiring callers to set the variable explicitly