### PR TITLE
INFRA-6098: Add `cluster_tag` to gateway API LB modules

### DIFF
--- a/kubernetes-gw-ext-alb.tf
+++ b/kubernetes-gw-ext-alb.tf
@@ -8,11 +8,12 @@ locals {
 }
 
 module "gateway_api_external_alb" {
-  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=v1.4.2"
+  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=v1.5.0"
   for_each = var.gateway_api_external_enabled ? toset([local.gateway_api_external_alb_name]) : []
 
   name_suffix  = each.key
   cluster_name = local.gateway_api_lb_name_prefix
+  cluster_tag  = var.cluster_name
   tag_prefix   = "gateway.k8s.aws.alb"
   tag_stack    = format("kube-system/%s", each.key)
 

--- a/kubernetes-gw-ext-alb.tf
+++ b/kubernetes-gw-ext-alb.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 module "gateway_api_external_alb" {
-  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=v1.5.0"
+  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=v1.5.1"
   for_each = var.gateway_api_external_enabled ? toset([local.gateway_api_external_alb_name]) : []
 
   name_suffix  = each.key

--- a/kubernetes-gw-ext-nlb.tf
+++ b/kubernetes-gw-ext-nlb.tf
@@ -26,12 +26,13 @@ locals {
 }
 
 module "gateway_api_external_nlb" {
-  source = "git@github.com:worldcoin/terraform-aws-nlb.git?ref=v1.3.0"
+  source = "git@github.com:worldcoin/terraform-aws-nlb.git?ref=v1.4.0"
 
   for_each = var.gateway_api_external_enabled ? toset([local.gateway_api_external_nlb_name]) : []
 
   name_suffix  = each.key
   cluster_name = local.gateway_api_lb_name_prefix
+  cluster_tag  = var.cluster_name
   tag_prefix   = "gateway.k8s.aws.nlb"
   tag_stack    = format("kube-system/%s", each.key)
 

--- a/kubernetes-gw-int-alb.tf
+++ b/kubernetes-gw-int-alb.tf
@@ -20,11 +20,12 @@ locals {
 }
 
 module "gateway_api_internal_alb" {
-  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=v1.4.2"
+  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=v1.5.0"
   for_each = var.gateway_api_internal_enabled ? toset([local.gateway_api_internal_alb_name]) : []
 
   name_suffix  = each.key
   cluster_name = local.gateway_api_lb_name_prefix
+  cluster_tag  = var.cluster_name
   tag_prefix   = "gateway.k8s.aws.alb"
   tag_stack    = format("kube-system/%s", each.key)
 

--- a/kubernetes-gw-int-alb.tf
+++ b/kubernetes-gw-int-alb.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 module "gateway_api_internal_alb" {
-  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=v1.5.0"
+  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=v1.5.1"
   for_each = var.gateway_api_internal_enabled ? toset([local.gateway_api_internal_alb_name]) : []
 
   name_suffix  = each.key

--- a/kubernetes-gw-int-nlb.tf
+++ b/kubernetes-gw-int-nlb.tf
@@ -30,12 +30,13 @@ locals {
 }
 
 module "gateway_api_internal_nlb" {
-  source = "git@github.com:worldcoin/terraform-aws-nlb.git?ref=v1.3.0"
+  source = "git@github.com:worldcoin/terraform-aws-nlb.git?ref=v1.4.0"
 
   for_each = var.gateway_api_internal_enabled ? toset([local.gateway_api_internal_nlb_name]) : []
 
   name_suffix  = each.key
   cluster_name = local.gateway_api_lb_name_prefix
+  cluster_tag  = var.cluster_name
   tag_prefix   = "gateway.k8s.aws.nlb"
   tag_stack    = format("kube-system/%s", each.key)
 

--- a/tests/mocks/aws/data.tfmock.hcl
+++ b/tests/mocks/aws/data.tfmock.hcl
@@ -39,8 +39,9 @@ EOF
 
 mock_data "aws_vpc" {
   defaults = {
-    id         = "vpc-1234567890abcdef3" # Must match the vpc_id in your test variables
-    cidr_block = "10.0.0.0/16"
+    id              = "vpc-1234567890abcdef3"
+    cidr_block      = "10.0.0.0/16"
+    ipv6_cidr_block = ""
   }
 }
 


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-6098/add-support-for-custom-cluster-tag-in-albnlb-modules
Tested (yes/no): yes https://github.com/worldcoin/infrastructure/pull/38499
Description/Why: 
The LB name prefix may be shortened (e.g., via `gateway_api_lb_name_prefix`) to meet the **32**-character AWS limit, but the tag must exactly match the LBC `--cluster-name` for the controller to discover and adopt the load balancer.

The LBC discovers existing load balancers exclusively via tag filtering (`elbv2.k8s.aws/cluster` + `<tagPrefix>/stack`), not by loadBalancerName. If the tag does not match `--cluster-name`, the LBC will not find the existing load balancer and will attempt to create a new one, resulting in a name collision.
