### PR TITLE
INFRA-5792: decouple external cert arn requirement from internal only load balancers

### DIFF
--- a/tests/kubernetes-gateway-api.tftest.hcl
+++ b/tests/kubernetes-gateway-api.tftest.hcl
@@ -154,3 +154,67 @@ run "gateway_api_lb_prefix_missing_long_name_fails" {
     terraform_data.gateway_api_lb_name_validation,
   ]
 }
+
+# =============================================================================
+# Test: Internal-only gateway does not require external_cert_arn
+# =============================================================================
+run "gateway_api_internal_only_no_external_cert" {
+  command = plan
+
+  variables {
+    gateway_api_internal_enabled = true
+    external_alb_enabled         = false
+    internal_nlb_enabled         = false
+    external_cert_arn            = null
+    traefik_cert_arn             = null
+    internal_cert_arn            = "arn:aws:acm:us-east-1:123412341234:certificate/aabbcc11-1312-abcd-qwer-1a2s3d4f5g6h"
+  }
+
+  assert {
+    condition     = local.effective_internal_cert_arn == "arn:aws:acm:us-east-1:123412341234:certificate/aabbcc11-1312-abcd-qwer-1a2s3d4f5g6h"
+    error_message = "effective_internal_cert_arn should use internal_cert_arn when external_cert_arn is null"
+  }
+}
+
+# =============================================================================
+# Test: Internal-only gateway with internal_nlb_acm_arn fallback
+# =============================================================================
+run "gateway_api_internal_only_nlb_acm_fallback" {
+  command = plan
+
+  variables {
+    gateway_api_internal_enabled = true
+    external_alb_enabled         = false
+    internal_nlb_enabled         = false
+    external_cert_arn            = null
+    traefik_cert_arn             = null
+    internal_cert_arn            = ""
+    internal_nlb_acm_arn         = "arn:aws:acm:us-east-1:123412341234:certificate/aabbcc11-1312-abcd-qwer-1a2s3d4f5g6h"
+  }
+
+  assert {
+    condition     = local.effective_internal_cert_arn == "arn:aws:acm:us-east-1:123412341234:certificate/aabbcc11-1312-abcd-qwer-1a2s3d4f5g6h"
+    error_message = "effective_internal_cert_arn should fall back to internal_nlb_acm_arn"
+  }
+}
+
+# =============================================================================
+# Test: Internal-only gateway with no cert at all must fail
+# =============================================================================
+run "gateway_api_internal_only_no_cert_fails" {
+  command = plan
+
+  variables {
+    gateway_api_internal_enabled = true
+    external_alb_enabled         = false
+    internal_nlb_enabled         = false
+    external_cert_arn            = null
+    traefik_cert_arn             = null
+    internal_cert_arn            = ""
+    internal_nlb_acm_arn         = ""
+  }
+
+  expect_failures = [
+    var.internal_cert_arn,
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -786,15 +786,13 @@ variable "external_cert_arn" {
   default     = null
   validation {
     condition = (
-      var.internal_nlb_enabled ||
       var.external_alb_enabled ||
-      var.gateway_api_external_enabled ||
-      var.gateway_api_internal_enabled
+      var.gateway_api_external_enabled
       ) ? (
       can(regex("^arn:aws:acm:[a-z][a-z]-[a-z]+-[1-9]:[0-9]{12}:certificate/[A-Za-z0-9\\-]+$", var.external_cert_arn)) ||
       can(regex("^arn:aws:acm:[a-z][a-z]-[a-z]+-[1-9]:[0-9]{12}:certificate/[A-Za-z0-9\\-]+$", var.traefik_cert_arn))
     ) : true
-    error_message = "A valid ACM certificate ARN must be set in external_cert_arn (or traefik_cert_arn) when any load balancer is enabled"
+    error_message = "A valid ACM certificate ARN must be set in external_cert_arn (or traefik_cert_arn) when an external load balancer is enabled"
   }
 }
 
@@ -802,6 +800,18 @@ variable "internal_cert_arn" {
   description = "ACM certificate ARN for internal load balancers (falls back to external_cert_arn). If empty, internal_nlb_acm_arn is used for backwards compatibility."
   type        = string
   default     = ""
+  validation {
+    condition = (
+      var.internal_nlb_enabled ||
+      var.gateway_api_internal_enabled
+      ) ? (
+      var.internal_cert_arn != "" ||
+      var.internal_nlb_acm_arn != "" ||
+      can(regex("^arn:aws:acm:[a-z][a-z]-[a-z]+-[1-9]:[0-9]{12}:certificate/[A-Za-z0-9\\-]+$", var.external_cert_arn)) ||
+      can(regex("^arn:aws:acm:[a-z][a-z]-[a-z]+-[1-9]:[0-9]{12}:certificate/[A-Za-z0-9\\-]+$", var.traefik_cert_arn))
+    ) : true
+    error_message = "A valid ACM certificate ARN must be set in internal_cert_arn, internal_nlb_acm_arn, or external_cert_arn when an internal load balancer is enabled"
+  }
 }
 
 variable "internal_nlb_service_ports" {


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-5792/update-common-app-to-create-new-objects
Tested (yes/no): yes
- https://github.com/worldcoin/infrastructure/pull/38559
- https://tfe.worldcoin.dev/app/TFH/workspaces/internal-tools-dev-us-east-1/runs/run-yraCjPJLnnGHDQzQ

Description/Why: to fix the error below
<img width="864" height="94" alt="image" src="https://github.com/user-attachments/assets/05179e0a-47d6-42b1-85a9-22a19e118e27" />

