### PR TITLE
INFRA-6190: Add customizable listeners for Gateway API LBs

### DIFF
--- a/kubernetes-gateway-api-manifests.tf
+++ b/kubernetes-gateway-api-manifests.tf
@@ -117,6 +117,8 @@ resource "kubernetes_manifest" "gateway_class_nlb" {
 resource "kubernetes_manifest" "gw_ext_alb_config" {
   count = local.gateway_api_crds_ready && var.gateway_api_external_enabled ? 1 : 0
 
+  computed_fields = ["spec.listenerConfigurations"]
+
   field_manager {
     force_conflicts = true
   }
@@ -170,6 +172,8 @@ resource "kubernetes_manifest" "gw_ext_alb" {
 
 resource "kubernetes_manifest" "gw_ext_nlb_config" {
   count = local.gateway_api_crds_ready && var.gateway_api_external_enabled ? 1 : 0
+
+  computed_fields = ["spec.listenerConfigurations"]
 
   field_manager {
     force_conflicts = true
@@ -225,6 +229,8 @@ resource "kubernetes_manifest" "gw_ext_nlb" {
 resource "kubernetes_manifest" "gw_int_alb_config" {
   count = local.gateway_api_crds_ready && var.gateway_api_internal_enabled ? 1 : 0
 
+  computed_fields = ["spec.listenerConfigurations"]
+
   field_manager {
     force_conflicts = true
   }
@@ -278,6 +284,8 @@ resource "kubernetes_manifest" "gw_int_alb" {
 
 resource "kubernetes_manifest" "gw_int_nlb_config" {
   count = local.gateway_api_crds_ready && var.gateway_api_internal_enabled ? 1 : 0
+
+  computed_fields = ["spec.listenerConfigurations"]
 
   field_manager {
     force_conflicts = true

--- a/kubernetes-gateway-api-manifests.tf
+++ b/kubernetes-gateway-api-manifests.tf
@@ -34,24 +34,28 @@ locals {
 
   _default_ext_alb_listener_configs = [{
     protocolPort       = "HTTPS:443"
+    alpnPolicy         = "None"
     sslPolicy          = local.gateway_api_ssl_policies[var.external_tls_listener_version]
     defaultCertificate = local.effective_external_cert_arn
   }]
 
   _default_ext_nlb_listener_configs = [{
     protocolPort       = "TLS:443"
+    alpnPolicy         = "None"
     sslPolicy          = local.gateway_api_ssl_policies[var.external_tls_listener_version]
     defaultCertificate = local.effective_external_cert_arn
   }]
 
   _default_int_alb_listener_configs = [{
     protocolPort       = "HTTPS:443"
+    alpnPolicy         = "None"
     sslPolicy          = local.gateway_api_ssl_policies[var.internal_tls_listener_version]
     defaultCertificate = local.effective_internal_cert_arn
   }]
 
   _default_int_nlb_listener_configs = [{
     protocolPort       = "TLS:443"
+    alpnPolicy         = "None"
     sslPolicy          = local.gateway_api_ssl_policies[var.internal_tls_listener_version]
     defaultCertificate = local.effective_internal_cert_arn
   }]

--- a/kubernetes-gateway-api-manifests.tf
+++ b/kubernetes-gateway-api-manifests.tf
@@ -60,10 +60,10 @@ locals {
     defaultCertificate = local.effective_internal_cert_arn
   }]
 
-  gateway_api_ext_alb_listener_configs = [for cfg in coalesce(var.gateway_api_ext_alb_listener_configs, local._default_ext_alb_listener_configs) : merge(local._listener_config_defaults, cfg)]
-  gateway_api_ext_nlb_listener_configs = [for cfg in coalesce(var.gateway_api_ext_nlb_listener_configs, local._default_ext_nlb_listener_configs) : merge(local._listener_config_defaults, cfg)]
-  gateway_api_int_alb_listener_configs = [for cfg in coalesce(var.gateway_api_int_alb_listener_configs, local._default_int_alb_listener_configs) : merge(local._listener_config_defaults, cfg)]
-  gateway_api_int_nlb_listener_configs = [for cfg in coalesce(var.gateway_api_int_nlb_listener_configs, local._default_int_nlb_listener_configs) : merge(local._listener_config_defaults, cfg)]
+  gateway_api_ext_alb_listener_configs = [for cfg in coalesce(var.gateway_api_ext_alb_listener_configs, local._default_ext_alb_listener_configs) : { for k, v in merge(local._listener_config_defaults, cfg) : k => v if v != null }]
+  gateway_api_ext_nlb_listener_configs = [for cfg in coalesce(var.gateway_api_ext_nlb_listener_configs, local._default_ext_nlb_listener_configs) : { for k, v in merge(local._listener_config_defaults, cfg) : k => v if v != null }]
+  gateway_api_int_alb_listener_configs = [for cfg in coalesce(var.gateway_api_int_alb_listener_configs, local._default_int_alb_listener_configs) : { for k, v in merge(local._listener_config_defaults, cfg) : k => v if v != null }]
+  gateway_api_int_nlb_listener_configs = [for cfg in coalesce(var.gateway_api_int_nlb_listener_configs, local._default_int_nlb_listener_configs) : { for k, v in merge(local._listener_config_defaults, cfg) : k => v if v != null }]
 }
 
 # CRDs: Gateway API (v1.5.1) + AWS LBC Gateway CRDs (v3.2.1)

--- a/kubernetes-gateway-api-manifests.tf
+++ b/kubernetes-gateway-api-manifests.tf
@@ -20,6 +20,39 @@ locals {
     for crd in concat(local._gateway_api_crd_docs, local._aws_lbc_crd_docs) :
     format("%s/%s", crd.kind, crd.metadata.name) => crd
   }
+
+  _default_ext_alb_listener_configs = [{
+    protocolPort       = "HTTPS:443"
+    alpnPolicy         = "None"
+    sslPolicy          = local.gateway_api_ssl_policies[var.external_tls_listener_version]
+    defaultCertificate = local.effective_external_cert_arn
+  }]
+
+  _default_ext_nlb_listener_configs = [{
+    protocolPort       = "TLS:443"
+    alpnPolicy         = "None"
+    sslPolicy          = local.gateway_api_ssl_policies[var.external_tls_listener_version]
+    defaultCertificate = local.effective_external_cert_arn
+  }]
+
+  _default_int_alb_listener_configs = [{
+    protocolPort       = "HTTPS:443"
+    alpnPolicy         = "None"
+    sslPolicy          = local.gateway_api_ssl_policies[var.internal_tls_listener_version]
+    defaultCertificate = local.effective_internal_cert_arn
+  }]
+
+  _default_int_nlb_listener_configs = [{
+    protocolPort       = "TLS:443"
+    alpnPolicy         = "None"
+    sslPolicy          = local.gateway_api_ssl_policies[var.internal_tls_listener_version]
+    defaultCertificate = local.effective_internal_cert_arn
+  }]
+
+  gateway_api_ext_alb_listener_configs = coalesce(var.gateway_api_ext_alb_listener_configs, local._default_ext_alb_listener_configs)
+  gateway_api_ext_nlb_listener_configs = coalesce(var.gateway_api_ext_nlb_listener_configs, local._default_ext_nlb_listener_configs)
+  gateway_api_int_alb_listener_configs = coalesce(var.gateway_api_int_alb_listener_configs, local._default_int_alb_listener_configs)
+  gateway_api_int_nlb_listener_configs = coalesce(var.gateway_api_int_nlb_listener_configs, local._default_int_nlb_listener_configs)
 }
 
 # CRDs: Gateway API (v1.5.1) + AWS LBC Gateway CRDs (v3.2.1)
@@ -101,12 +134,7 @@ resource "kubernetes_manifest" "gw_ext_alb_config" {
       scheme                          = "internet-facing"
       securityGroups                  = [for _, id in module.gateway_api_external_alb[local.gateway_api_external_alb_name].sg_ids : id if id != null]
       manageBackendSecurityGroupRules = false
-      listenerConfigurations = [{
-        protocolPort       = "HTTPS:443"
-        alpnPolicy         = "None"
-        sslPolicy          = local.gateway_api_ssl_policies[var.external_tls_listener_version]
-        defaultCertificate = local.effective_external_cert_arn
-      }]
+      listenerConfigurations          = local.gateway_api_ext_alb_listener_configs
     }
   }
 }
@@ -135,24 +163,7 @@ resource "kubernetes_manifest" "gw_ext_alb" {
           name  = local.gateway_api_external_alb_name
         }
       }
-      listeners = [{
-        name     = "https"
-        protocol = "HTTPS"
-        port     = 443
-        tls = {
-          mode = "Terminate"
-          certificateRefs = [{
-            group = ""
-            kind  = "Secret"
-            name  = "default-cert"
-          }]
-        }
-        allowedRoutes = {
-          namespaces = {
-            from = "All"
-          }
-        }
-      }]
+      listeners = var.gateway_api_ext_alb_listeners
     }
   }
 }
@@ -177,12 +188,7 @@ resource "kubernetes_manifest" "gw_ext_nlb_config" {
       scheme                          = "internet-facing"
       securityGroups                  = [module.gateway_api_external_nlb[local.gateway_api_external_nlb_name].sg_nlb_id]
       manageBackendSecurityGroupRules = false
-      listenerConfigurations = [{
-        protocolPort       = "TLS:443"
-        alpnPolicy         = "None"
-        sslPolicy          = local.gateway_api_ssl_policies[var.external_tls_listener_version]
-        defaultCertificate = local.effective_external_cert_arn
-      }]
+      listenerConfigurations          = local.gateway_api_ext_nlb_listener_configs
     }
   }
 }
@@ -211,44 +217,7 @@ resource "kubernetes_manifest" "gw_ext_nlb" {
           name  = local.gateway_api_external_nlb_name
         }
       }
-      listeners = [
-        {
-          name     = "tcp"
-          protocol = "TCP"
-          port     = 80
-          allowedRoutes = {
-            namespaces = {
-              from = "All"
-            }
-            kinds = [{
-              group = "gateway.networking.k8s.io"
-              kind  = "TCPRoute"
-            }]
-          }
-        },
-        {
-          name     = "tls"
-          protocol = "TLS"
-          port     = 443
-          tls = {
-            mode = "Terminate"
-            certificateRefs = [{
-              group = ""
-              kind  = "Secret"
-              name  = "default-cert"
-            }]
-          }
-          allowedRoutes = {
-            namespaces = {
-              from = "All"
-            }
-            kinds = [{
-              group = "gateway.networking.k8s.io"
-              kind  = "TLSRoute"
-            }]
-          }
-        },
-      ]
+      listeners = var.gateway_api_ext_nlb_listeners
     }
   }
 }
@@ -273,12 +242,7 @@ resource "kubernetes_manifest" "gw_int_alb_config" {
       scheme                          = "internal"
       securityGroups                  = [for _, id in module.gateway_api_internal_alb[local.gateway_api_internal_alb_name].sg_ids : id if id != null]
       manageBackendSecurityGroupRules = false
-      listenerConfigurations = [{
-        protocolPort       = "HTTPS:443"
-        alpnPolicy         = "None"
-        sslPolicy          = local.gateway_api_ssl_policies[var.internal_tls_listener_version]
-        defaultCertificate = local.effective_internal_cert_arn
-      }]
+      listenerConfigurations          = local.gateway_api_int_alb_listener_configs
     }
   }
 }
@@ -307,24 +271,7 @@ resource "kubernetes_manifest" "gw_int_alb" {
           name  = local.gateway_api_internal_alb_name
         }
       }
-      listeners = [{
-        name     = "https"
-        protocol = "HTTPS"
-        port     = 443
-        tls = {
-          mode = "Terminate"
-          certificateRefs = [{
-            group = ""
-            kind  = "Secret"
-            name  = "default-cert"
-          }]
-        }
-        allowedRoutes = {
-          namespaces = {
-            from = "All"
-          }
-        }
-      }]
+      listeners = var.gateway_api_int_alb_listeners
     }
   }
 }
@@ -349,12 +296,7 @@ resource "kubernetes_manifest" "gw_int_nlb_config" {
       scheme                          = "internal"
       securityGroups                  = [module.gateway_api_internal_nlb[local.gateway_api_internal_nlb_name].sg_nlb_id]
       manageBackendSecurityGroupRules = false
-      listenerConfigurations = [{
-        protocolPort       = "TLS:443"
-        alpnPolicy         = "None"
-        sslPolicy          = local.gateway_api_ssl_policies[var.internal_tls_listener_version]
-        defaultCertificate = local.effective_internal_cert_arn
-      }]
+      listenerConfigurations          = local.gateway_api_int_nlb_listener_configs
     }
   }
 }
@@ -383,44 +325,7 @@ resource "kubernetes_manifest" "gw_int_nlb" {
           name  = local.gateway_api_internal_nlb_name
         }
       }
-      listeners = [
-        {
-          name     = "tcp"
-          protocol = "TCP"
-          port     = 80
-          allowedRoutes = {
-            namespaces = {
-              from = "All"
-            }
-            kinds = [{
-              group = "gateway.networking.k8s.io"
-              kind  = "TCPRoute"
-            }]
-          }
-        },
-        {
-          name     = "tls"
-          protocol = "TLS"
-          port     = 443
-          tls = {
-            mode = "Terminate"
-            certificateRefs = [{
-              group = ""
-              kind  = "Secret"
-              name  = "default-cert"
-            }]
-          }
-          allowedRoutes = {
-            namespaces = {
-              from = "All"
-            }
-            kinds = [{
-              group = "gateway.networking.k8s.io"
-              kind  = "TLSRoute"
-            }]
-          }
-        },
-      ]
+      listeners = var.gateway_api_int_nlb_listeners
     }
   }
 }

--- a/kubernetes-gateway-api-manifests.tf
+++ b/kubernetes-gateway-api-manifests.tf
@@ -21,6 +21,11 @@ locals {
     format("%s/%s", crd.kind, crd.metadata.name) => crd
   }
 
+  # All LoadBalancerConfiguration CRD attributes with null defaults.
+  # Used by merge() to satisfy the kubernetes_manifest provider's requirement
+  # that all CRD attributes are present in the object (even optional ones).
+  # Values are null so they get stripped by the `if v != null` filter below,
+  # avoiding drift on clusters that don't set these attributes.
   _listener_config_defaults = {
     alpnPolicy            = null
     sslPolicy             = null
@@ -60,6 +65,10 @@ locals {
     defaultCertificate = local.effective_internal_cert_arn
   }]
 
+  # Resolve listener configs: use override if provided, otherwise per-LB defaults.
+  # merge() ensures all CRD attributes exist (required by kubernetes_manifest provider),
+  # then `if v != null` strips null keys so only caller-set fields appear in the manifest,
+  # preventing drift on clusters using defaults.
   gateway_api_ext_alb_listener_configs = [for cfg in coalesce(var.gateway_api_ext_alb_listener_configs, local._default_ext_alb_listener_configs) : { for k, v in merge(local._listener_config_defaults, cfg) : k => v if v != null }]
   gateway_api_ext_nlb_listener_configs = [for cfg in coalesce(var.gateway_api_ext_nlb_listener_configs, local._default_ext_nlb_listener_configs) : { for k, v in merge(local._listener_config_defaults, cfg) : k => v if v != null }]
   gateway_api_int_alb_listener_configs = [for cfg in coalesce(var.gateway_api_int_alb_listener_configs, local._default_int_alb_listener_configs) : { for k, v in merge(local._listener_config_defaults, cfg) : k => v if v != null }]

--- a/kubernetes-gateway-api-manifests.tf
+++ b/kubernetes-gateway-api-manifests.tf
@@ -22,14 +22,14 @@ locals {
   }
 
   _listener_config_defaults = {
-    alpnPolicy            = "None"
-    sslPolicy             = ""
-    defaultCertificate    = ""
-    certificates          = []
-    listenerAttributes    = []
+    alpnPolicy            = null
+    sslPolicy             = null
+    defaultCertificate    = null
+    certificates          = null
+    listenerAttributes    = null
     mutualAuthentication  = null
-    quicEnabled           = false
-    targetGroupStickiness = false
+    quicEnabled           = null
+    targetGroupStickiness = null
   }
 
   _default_ext_alb_listener_configs = [{
@@ -56,10 +56,10 @@ locals {
     defaultCertificate = local.effective_internal_cert_arn
   }]
 
-  gateway_api_ext_alb_listener_configs = var.gateway_api_ext_alb_listener_configs != null ? [for cfg in var.gateway_api_ext_alb_listener_configs : merge(local._listener_config_defaults, cfg)] : local._default_ext_alb_listener_configs
-  gateway_api_ext_nlb_listener_configs = var.gateway_api_ext_nlb_listener_configs != null ? [for cfg in var.gateway_api_ext_nlb_listener_configs : merge(local._listener_config_defaults, cfg)] : local._default_ext_nlb_listener_configs
-  gateway_api_int_alb_listener_configs = var.gateway_api_int_alb_listener_configs != null ? [for cfg in var.gateway_api_int_alb_listener_configs : merge(local._listener_config_defaults, cfg)] : local._default_int_alb_listener_configs
-  gateway_api_int_nlb_listener_configs = var.gateway_api_int_nlb_listener_configs != null ? [for cfg in var.gateway_api_int_nlb_listener_configs : merge(local._listener_config_defaults, cfg)] : local._default_int_nlb_listener_configs
+  gateway_api_ext_alb_listener_configs = [for cfg in coalesce(var.gateway_api_ext_alb_listener_configs, local._default_ext_alb_listener_configs) : merge(local._listener_config_defaults, cfg)]
+  gateway_api_ext_nlb_listener_configs = [for cfg in coalesce(var.gateway_api_ext_nlb_listener_configs, local._default_ext_nlb_listener_configs) : merge(local._listener_config_defaults, cfg)]
+  gateway_api_int_alb_listener_configs = [for cfg in coalesce(var.gateway_api_int_alb_listener_configs, local._default_int_alb_listener_configs) : merge(local._listener_config_defaults, cfg)]
+  gateway_api_int_nlb_listener_configs = [for cfg in coalesce(var.gateway_api_int_nlb_listener_configs, local._default_int_nlb_listener_configs) : merge(local._listener_config_defaults, cfg)]
 }
 
 # CRDs: Gateway API (v1.5.1) + AWS LBC Gateway CRDs (v3.2.1)

--- a/kubernetes-gateway-api-manifests.tf
+++ b/kubernetes-gateway-api-manifests.tf
@@ -21,38 +21,45 @@ locals {
     format("%s/%s", crd.kind, crd.metadata.name) => crd
   }
 
+  _listener_config_defaults = {
+    alpnPolicy            = "None"
+    sslPolicy             = ""
+    defaultCertificate    = ""
+    certificates          = []
+    listenerAttributes    = []
+    mutualAuthentication  = null
+    quicEnabled           = false
+    targetGroupStickiness = false
+  }
+
   _default_ext_alb_listener_configs = [{
     protocolPort       = "HTTPS:443"
-    alpnPolicy         = "None"
     sslPolicy          = local.gateway_api_ssl_policies[var.external_tls_listener_version]
     defaultCertificate = local.effective_external_cert_arn
   }]
 
   _default_ext_nlb_listener_configs = [{
     protocolPort       = "TLS:443"
-    alpnPolicy         = "None"
     sslPolicy          = local.gateway_api_ssl_policies[var.external_tls_listener_version]
     defaultCertificate = local.effective_external_cert_arn
   }]
 
   _default_int_alb_listener_configs = [{
     protocolPort       = "HTTPS:443"
-    alpnPolicy         = "None"
     sslPolicy          = local.gateway_api_ssl_policies[var.internal_tls_listener_version]
     defaultCertificate = local.effective_internal_cert_arn
   }]
 
   _default_int_nlb_listener_configs = [{
     protocolPort       = "TLS:443"
-    alpnPolicy         = "None"
     sslPolicy          = local.gateway_api_ssl_policies[var.internal_tls_listener_version]
     defaultCertificate = local.effective_internal_cert_arn
   }]
 
-  gateway_api_ext_alb_listener_configs = coalesce(var.gateway_api_ext_alb_listener_configs, local._default_ext_alb_listener_configs)
-  gateway_api_ext_nlb_listener_configs = coalesce(var.gateway_api_ext_nlb_listener_configs, local._default_ext_nlb_listener_configs)
-  gateway_api_int_alb_listener_configs = coalesce(var.gateway_api_int_alb_listener_configs, local._default_int_alb_listener_configs)
-  gateway_api_int_nlb_listener_configs = coalesce(var.gateway_api_int_nlb_listener_configs, local._default_int_nlb_listener_configs)
+  gateway_api_ext_alb_listener_configs = [for cfg in coalesce(var.gateway_api_ext_alb_listener_configs, local._default_ext_alb_listener_configs) : merge(local._listener_config_defaults, cfg)]
+  gateway_api_ext_nlb_listener_configs = [for cfg in coalesce(var.gateway_api_ext_nlb_listener_configs, local._default_ext_nlb_listener_configs) : merge(local._listener_config_defaults, cfg)]
+  gateway_api_int_alb_listener_configs = [for cfg in coalesce(var.gateway_api_int_alb_listener_configs, local._default_int_alb_listener_configs) : merge(local._listener_config_defaults, cfg)]
+  gateway_api_int_nlb_listener_configs = [for cfg in coalesce(var.gateway_api_int_nlb_listener_configs, local._default_int_nlb_listener_configs) : merge(local._listener_config_defaults, cfg)]
 }
 
 # CRDs: Gateway API (v1.5.1) + AWS LBC Gateway CRDs (v3.2.1)
@@ -117,8 +124,6 @@ resource "kubernetes_manifest" "gateway_class_nlb" {
 resource "kubernetes_manifest" "gw_ext_alb_config" {
   count = local.gateway_api_crds_ready && var.gateway_api_external_enabled ? 1 : 0
 
-  computed_fields = ["spec.listenerConfigurations"]
-
   field_manager {
     force_conflicts = true
   }
@@ -172,8 +177,6 @@ resource "kubernetes_manifest" "gw_ext_alb" {
 
 resource "kubernetes_manifest" "gw_ext_nlb_config" {
   count = local.gateway_api_crds_ready && var.gateway_api_external_enabled ? 1 : 0
-
-  computed_fields = ["spec.listenerConfigurations"]
 
   field_manager {
     force_conflicts = true
@@ -229,8 +232,6 @@ resource "kubernetes_manifest" "gw_ext_nlb" {
 resource "kubernetes_manifest" "gw_int_alb_config" {
   count = local.gateway_api_crds_ready && var.gateway_api_internal_enabled ? 1 : 0
 
-  computed_fields = ["spec.listenerConfigurations"]
-
   field_manager {
     force_conflicts = true
   }
@@ -284,8 +285,6 @@ resource "kubernetes_manifest" "gw_int_alb" {
 
 resource "kubernetes_manifest" "gw_int_nlb_config" {
   count = local.gateway_api_crds_ready && var.gateway_api_internal_enabled ? 1 : 0
-
-  computed_fields = ["spec.listenerConfigurations"]
 
   field_manager {
     force_conflicts = true

--- a/kubernetes-gateway-api-manifests.tf
+++ b/kubernetes-gateway-api-manifests.tf
@@ -56,10 +56,10 @@ locals {
     defaultCertificate = local.effective_internal_cert_arn
   }]
 
-  gateway_api_ext_alb_listener_configs = [for cfg in coalesce(var.gateway_api_ext_alb_listener_configs, local._default_ext_alb_listener_configs) : merge(local._listener_config_defaults, cfg)]
-  gateway_api_ext_nlb_listener_configs = [for cfg in coalesce(var.gateway_api_ext_nlb_listener_configs, local._default_ext_nlb_listener_configs) : merge(local._listener_config_defaults, cfg)]
-  gateway_api_int_alb_listener_configs = [for cfg in coalesce(var.gateway_api_int_alb_listener_configs, local._default_int_alb_listener_configs) : merge(local._listener_config_defaults, cfg)]
-  gateway_api_int_nlb_listener_configs = [for cfg in coalesce(var.gateway_api_int_nlb_listener_configs, local._default_int_nlb_listener_configs) : merge(local._listener_config_defaults, cfg)]
+  gateway_api_ext_alb_listener_configs = var.gateway_api_ext_alb_listener_configs != null ? [for cfg in var.gateway_api_ext_alb_listener_configs : merge(local._listener_config_defaults, cfg)] : local._default_ext_alb_listener_configs
+  gateway_api_ext_nlb_listener_configs = var.gateway_api_ext_nlb_listener_configs != null ? [for cfg in var.gateway_api_ext_nlb_listener_configs : merge(local._listener_config_defaults, cfg)] : local._default_ext_nlb_listener_configs
+  gateway_api_int_alb_listener_configs = var.gateway_api_int_alb_listener_configs != null ? [for cfg in var.gateway_api_int_alb_listener_configs : merge(local._listener_config_defaults, cfg)] : local._default_int_alb_listener_configs
+  gateway_api_int_nlb_listener_configs = var.gateway_api_int_nlb_listener_configs != null ? [for cfg in var.gateway_api_int_nlb_listener_configs : merge(local._listener_config_defaults, cfg)] : local._default_int_nlb_listener_configs
 }
 
 # CRDs: Gateway API (v1.5.1) + AWS LBC Gateway CRDs (v3.2.1)

--- a/tests/kubernetes-gateway-api.tftest.hcl
+++ b/tests/kubernetes-gateway-api.tftest.hcl
@@ -263,7 +263,7 @@ run "gateway_api_k8s_manifests_external_enabled" {
   command = plan
 
   variables {
-    kubernetes_provider_enabled   = true
+    kubernetes_provider_enabled  = true
     gateway_api_crds_enabled     = true
     gateway_api_external_enabled = true
     gateway_api_lb_name_prefix   = "test"
@@ -322,7 +322,7 @@ run "gateway_api_k8s_manifests_internal_enabled" {
   command = plan
 
   variables {
-    kubernetes_provider_enabled   = true
+    kubernetes_provider_enabled  = true
     gateway_api_crds_enabled     = true
     gateway_api_internal_enabled = true
     gateway_api_lb_name_prefix   = "test"

--- a/tests/terraform.tfvars
+++ b/tests/terraform.tfvars
@@ -14,7 +14,7 @@ external_cert_arn = "arn:aws:acm:ap-south-1:123412341234:certificate/aabbcc11-13
 alb_logs_bucket_id = "some-bucket"
 
 internal_nlb_enabled = true
-internal_cert_arn = "arn:aws:acm:ap-south-1:123412341234:certificate/anlbcc11-1312-abcd-qwer-1a2s3d4f5g6h"
+internal_cert_arn    = "arn:aws:acm:ap-south-1:123412341234:certificate/anlbcc11-1312-abcd-qwer-1a2s3d4f5g6h"
 
 wafv2_arn = "arn:aws:wafv2:ap-south-1:123123123123:regional/webacl/foo-bar-123-baz/1a2w3e4r-zaq1-2wsx-qwer-098aa8900990"
 

--- a/variables.tf
+++ b/variables.tf
@@ -910,6 +910,162 @@ variable "gateway_api_internal_nlb_sg_rules" {
   }
 }
 
+variable "gateway_api_ext_alb_listeners" {
+  description = "Gateway listeners for the external ALB (gw-ext-alb)."
+  type        = any
+  default = [{
+    name     = "https"
+    protocol = "HTTPS"
+    port     = 443
+    tls = {
+      mode = "Terminate"
+      certificateRefs = [{
+        group = ""
+        kind  = "Secret"
+        name  = "default-cert"
+      }]
+    }
+    allowedRoutes = {
+      namespaces = {
+        from = "All"
+      }
+    }
+  }]
+}
+
+variable "gateway_api_ext_nlb_listeners" {
+  description = "Gateway listeners for the external NLB (gw-ext-nlb)."
+  type        = any
+  default = [
+    {
+      name     = "tcp"
+      protocol = "TCP"
+      port     = 80
+      allowedRoutes = {
+        namespaces = {
+          from = "All"
+        }
+        kinds = [{
+          group = "gateway.networking.k8s.io"
+          kind  = "TCPRoute"
+        }]
+      }
+    },
+    {
+      name     = "tls"
+      protocol = "TLS"
+      port     = 443
+      tls = {
+        mode = "Terminate"
+        certificateRefs = [{
+          group = ""
+          kind  = "Secret"
+          name  = "default-cert"
+        }]
+      }
+      allowedRoutes = {
+        namespaces = {
+          from = "All"
+        }
+        kinds = [{
+          group = "gateway.networking.k8s.io"
+          kind  = "TLSRoute"
+        }]
+      }
+    },
+  ]
+}
+
+variable "gateway_api_int_alb_listeners" {
+  description = "Gateway listeners for the internal ALB (gw-int-alb)."
+  type        = any
+  default = [{
+    name     = "https"
+    protocol = "HTTPS"
+    port     = 443
+    tls = {
+      mode = "Terminate"
+      certificateRefs = [{
+        group = ""
+        kind  = "Secret"
+        name  = "default-cert"
+      }]
+    }
+    allowedRoutes = {
+      namespaces = {
+        from = "All"
+      }
+    }
+  }]
+}
+
+variable "gateway_api_int_nlb_listeners" {
+  description = "Gateway listeners for the internal NLB (gw-int-nlb)."
+  type        = any
+  default = [
+    {
+      name     = "tcp"
+      protocol = "TCP"
+      port     = 80
+      allowedRoutes = {
+        namespaces = {
+          from = "All"
+        }
+        kinds = [{
+          group = "gateway.networking.k8s.io"
+          kind  = "TCPRoute"
+        }]
+      }
+    },
+    {
+      name     = "tls"
+      protocol = "TLS"
+      port     = 443
+      tls = {
+        mode = "Terminate"
+        certificateRefs = [{
+          group = ""
+          kind  = "Secret"
+          name  = "default-cert"
+        }]
+      }
+      allowedRoutes = {
+        namespaces = {
+          from = "All"
+        }
+        kinds = [{
+          group = "gateway.networking.k8s.io"
+          kind  = "TLSRoute"
+        }]
+      }
+    },
+  ]
+}
+
+variable "gateway_api_ext_alb_listener_configs" {
+  description = "Override LoadBalancerConfiguration listenerConfigurations for the external ALB. When null, defaults to HTTPS:443 with external cert and SSL policy."
+  type        = any
+  default     = null
+}
+
+variable "gateway_api_ext_nlb_listener_configs" {
+  description = "Override LoadBalancerConfiguration listenerConfigurations for the external NLB. When null, defaults to TLS:443 with external cert and SSL policy."
+  type        = any
+  default     = null
+}
+
+variable "gateway_api_int_alb_listener_configs" {
+  description = "Override LoadBalancerConfiguration listenerConfigurations for the internal ALB. When null, defaults to HTTPS:443 with internal cert and SSL policy."
+  type        = any
+  default     = null
+}
+
+variable "gateway_api_int_nlb_listener_configs" {
+  description = "Override LoadBalancerConfiguration listenerConfigurations for the internal NLB. When null, defaults to TLS:443 with internal cert and SSL policy."
+  type        = any
+  default     = null
+}
+
 variable "gateway_api_lb_name_prefix" {
   description = "Prefix for Gateway API load balancer names. Defaults to cluster_name. Override when cluster_name is too long to fit within the 32-char AWS LB name limit (prefix + suffix like '-gw-ext-alb' must be <= 32)."
   type        = string


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-6190/move-crd-and-gateway-config-management-to-terraform-aws-eks
Tested (yes/no): yes https://github.com/worldcoin/infrastructure/pull/39760
Related PR: https://github.com/worldcoin/cluster-apps/pull/2260
Description/Why: the new listener variables allow clusters with non-standard Gateway configurations (like blockchain's ethereum-rpc on TCP:8545) to be migrated from Helm to Terraform without the module overwriting their custom listeners with hardcoded defaults
