### PR TITLE
INFRA-6242 Use new, more restrictive EBS CSI policy

### DIFF
--- a/cluster-addons.tf
+++ b/cluster-addons.tf
@@ -26,8 +26,8 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
   # aws eks describe-addon-versions --addon-name aws-ebs-csi-driver | jq '.addons[0].addonVersions[0]'
   ebs_csi_driver_version = {
-    "1.32" = "v1.48.0-eksbuild.2"
-    "1.33" = "v1.48.0-eksbuild.2"
+    "1.32" = "v1.58.0-eksbuild.1"
+    "1.33" = "v1.58.0-eksbuild.1"
   }
 
   # https://docs.aws.amazon.com/eks/latest/userguide/workloads-add-ons-available-eks.html#addons-csi-snapshot-controller

--- a/iam-ebs.tf
+++ b/iam-ebs.tf
@@ -23,7 +23,7 @@ resource "aws_iam_role" "ebs_csi_controller" {
 
 resource "aws_iam_role_policy_attachment" "ebs_csi_controller" {
   role       = aws_iam_role.ebs_csi_controller.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEBSCSIDriverPolicyV2"
 }
 
 resource "aws_eks_pod_identity_association" "ebs_csi_controller" {

--- a/iam-node.tf
+++ b/iam-node.tf
@@ -46,7 +46,7 @@ resource "aws_iam_role_policy_attachment" "node" {
     "AmazonEC2ContainerRegistryReadOnly",
     "AmazonEKS_CNI_Policy",
     "AmazonSSMManagedInstanceCore",
-    "service-role/AmazonEBSCSIDriverPolicy",
+    "AmazonEBSCSIDriverPolicyV2",
   ])
 
   policy_arn = "arn:aws:iam::aws:policy/${each.value}"


### PR DESCRIPTION
Requestor/Issue: INFRA-6242
Tested (yes/no): will be
Description/Why: Use new, more restrictive EBS CSI policy

AmazonEBSCSIDriverPolicyV2 is the tighter, least-privilege replacement.

Main difference:

* AmazonEBSCSIDriverPolicy lets the driver act on EBS volumes and snapshots broadly, including many resources not necessarily created or managed by the CSI driver. AWS says this broader scope was intentional to support things like static provisioning and snapshot restore.
* AmazonEBSCSIDriverPolicyV2 restricts most mutating actions to EBS resources tagged as CSI-managed with ebs.csi.aws.com/cluster=true. It also supports CSI-migrated in-tree volumes via the kubernetes.io/created-for/pvc/name tag.

