### PR TITLE
INFRA-6097 Enable drop_invalid_header_fields=true by default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -436,7 +436,7 @@ variable "additional_open_ports" {
 variable "drop_invalid_header_fields" {
   description = "Drop invalid header fields"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "wafv2_arn" {


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-6097/enable-drop-invalid-header-fieldstrue-by-default-in-terraform-aws-alb
Tested (yes/no): yes
Description/Why:

Passing unknown or invalid HTTP headers through to backend targets is a security risk. Enabling `drop_invalid_header_fields` removes non-standard headers at the load balancer level, reducing the attack surface.

This was flagged during a Trivy security scan ([AVD-AWS-0052](https://avd.aquasec.com/misconfig/aws/elb/avd-aws-0052/)) — ALB not configured to drop invalid headers.

**Deployment approach:** Apply to dev/stage environments first, verify no issues, then roll out to prod.

## References

* [AVD-AWS-0052](https://avd.aquasec.com/misconfig/aws/elb/avd-aws-0052/)