### PR TITLE
INFRA-6314: add EKS 1.34 and 1.35 addon version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,13 @@ This will change the authentication mode to API_AND_CONFIG_MAP, and the next ter
 
 The module is currently supporting the following versions of Kubernetes:
 
+- 1.32,
 - 1.33,
 - 1.34,
 - 1.35,
 
 > [!NOTE]
-> Default version for EKS Cluster is 1.35.
+> Default version for EKS Cluster is 1.33.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-c# terraform-aws-eks
+# terraform-aws-eks
 
 - [Description](#description)
 - [How to release](#how-to-release)
@@ -96,13 +96,12 @@ This will change the authentication mode to API_AND_CONFIG_MAP, and the next ter
 
 The module is currently supporting the following versions of Kubernetes:
 
-- 1.32,
 - 1.33,
 - 1.34,
 - 1.35,
 
 > [!NOTE]
-> Default version for EKS Cluster is 1.33.
+> Default version for EKS Cluster is 1.35.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# terraform-aws-eks
+c# terraform-aws-eks
 
 - [Description](#description)
 - [How to release](#how-to-release)
@@ -98,9 +98,11 @@ The module is currently supporting the following versions of Kubernetes:
 
 - 1.32,
 - 1.33,
+- 1.34,
+- 1.35,
 
 > [!NOTE]
-> Default version for EKS Cluster is 1.32.
+> Default version for EKS Cluster is 1.33.
 
 ## Examples
 

--- a/cluster-addons.tf
+++ b/cluster-addons.tf
@@ -3,6 +3,7 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
   # aws eks describe-addon-versions --addon-name vpc-cni --region us-east-1 --output json| jq '.addons[0].addonVersions[0]'
   vpc_cni_version = {
+    "1.32" = "v1.20.1-eksbuild.3"
     "1.33" = "v1.20.1-eksbuild.3"
     "1.34" = "v1.20.5-eksbuild.1"
     "1.35" = "v1.21.1-eksbuild.1"
@@ -12,6 +13,7 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
   # aws eks describe-addon-versions --addon-name coredns | jq '.addons[0].addonVersions[0]'
   coredns_version = {
+    "1.32" = "v1.11.4-eksbuild.22"
     "1.33" = "v1.11.4-eksbuild.22"
     "1.34" = "v1.12.4-eksbuild.10"
     "1.35" = "v1.13.2-eksbuild.4"
@@ -21,6 +23,7 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
   # aws eks describe-addon-versions --addon-name kube-proxy | jq '.addons[0].addonVersions[0]'
   kube_proxy_version = {
+    "1.32" = "v1.32.6-eksbuild.8"
     "1.33" = "v1.32.6-eksbuild.8"
     "1.34" = "v1.34.6-eksbuild.2"
     "1.35" = "v1.35.3-eksbuild.2"
@@ -29,6 +32,7 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
   # aws eks describe-addon-versions --addon-name aws-ebs-csi-driver | jq '.addons[0].addonVersions[0]'
   ebs_csi_driver_version = {
+    "1.32" = "v1.58.0-eksbuild.1"
     "1.33" = "v1.58.0-eksbuild.1"
     "1.34" = "v1.59.0-eksbuild.1"
     "1.35" = "v1.59.0-eksbuild.1"
@@ -38,6 +42,7 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/csi-snapshot-controller.html
   # aws eks describe-addon-versions --region us-east-1 --addon-name snapshot-controller | jq '.addons[0].addonVersions[0]'
   snapshot_controller = {
+    "1.32" = "v8.3.0-eksbuild.1"
     "1.33" = "v8.3.0-eksbuild.1"
     "1.34" = "v8.5.0-eksbuild.4"
     "1.35" = "v8.5.0-eksbuild.4"
@@ -46,6 +51,7 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/pod-id-agent-setup.html
   # aws eks describe-addon-versions --addon-name eks-pod-identity-agent | jq '.addons[0].addonVersions[0]'
   eks_pod_identity_agent_version = {
+    "1.32" = "v1.3.8-eksbuild.2"
     "1.33" = "v1.3.8-eksbuild.2"
     "1.34" = "v1.3.10-eksbuild.3"
     "1.35" = "v1.3.10-eksbuild.3"
@@ -54,6 +60,7 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/node-health.html
   # aws eks describe-addon-versions --addon-name eks-node-monitoring-agent | jq '.addons[0].addonVersions[0]'
   eks_node_monitoring_agent_version = {
+    "1.32" = "v1.4.0-eksbuild.2"
     "1.33" = "v1.4.0-eksbuild.2"
     "1.34" = "v1.6.4-eksbuild.1"
     "1.35" = "v1.6.4-eksbuild.1"
@@ -62,6 +69,7 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html#s3-install-driver
   # aws eks describe-addon-versions --addon-name aws-mountpoint-s3-csi-driver --region us-east-1 --output json| jq '.addons[0].addonVersions[0]'
   mountpoint_s3_csi_version = {
+    "1.32" = "v2.0.0-eksbuild.1"
     "1.33" = "v2.0.0-eksbuild.1"
     "1.34" = "v2.5.0-eksbuild.1"
     "1.35" = "v2.5.0-eksbuild.1"
@@ -70,6 +78,7 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/metrics-server.html
   # aws eks describe-addon-versions --addon-name metrics-server --region us-east-1 --output json| jq '.addons[0].addonVersions[0]'
   metrcis_server_version = {
+    "1.32" = "v0.8.0-eksbuild.2"
     "1.33" = "v0.8.0-eksbuild.2"
     "1.34" = "v0.8.1-eksbuild.6"
     "1.35" = "v0.8.1-eksbuild.6"

--- a/cluster-addons.tf
+++ b/cluster-addons.tf
@@ -5,6 +5,8 @@ locals {
   vpc_cni_version = {
     "1.32" = "v1.20.1-eksbuild.3"
     "1.33" = "v1.20.1-eksbuild.3"
+    "1.34" = "v1.20.5-eksbuild.1"
+    "1.35" = "v1.21.1-eksbuild.1"
   }
 
   # CoreDNS version deployed with each Amazon EKS supported cluster version
@@ -13,6 +15,8 @@ locals {
   coredns_version = {
     "1.32" = "v1.11.4-eksbuild.22"
     "1.33" = "v1.11.4-eksbuild.22"
+    "1.34" = "v1.12.4-eksbuild.10"
+    "1.35" = "v1.13.2-eksbuild.4"
   }
 
   # Latest available kube-proxy container image version for each Amazon EKS cluster version
@@ -21,6 +25,8 @@ locals {
   kube_proxy_version = {
     "1.32" = "v1.32.6-eksbuild.8"
     "1.33" = "v1.32.6-eksbuild.8"
+    "1.34" = "v1.34.6-eksbuild.2"
+    "1.35" = "v1.35.3-eksbuild.2"
   }
 
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
@@ -28,6 +34,8 @@ locals {
   ebs_csi_driver_version = {
     "1.32" = "v1.58.0-eksbuild.1"
     "1.33" = "v1.58.0-eksbuild.1"
+    "1.34" = "v1.59.0-eksbuild.1"
+    "1.35" = "v1.59.0-eksbuild.1"
   }
 
   # https://docs.aws.amazon.com/eks/latest/userguide/workloads-add-ons-available-eks.html#addons-csi-snapshot-controller
@@ -36,6 +44,8 @@ locals {
   snapshot_controller = {
     "1.32" = "v8.3.0-eksbuild.1"
     "1.33" = "v8.3.0-eksbuild.1"
+    "1.34" = "v8.5.0-eksbuild.4"
+    "1.35" = "v8.5.0-eksbuild.4"
   }
 
   # https://docs.aws.amazon.com/eks/latest/userguide/pod-id-agent-setup.html
@@ -43,6 +53,8 @@ locals {
   eks_pod_identity_agent_version = {
     "1.32" = "v1.3.8-eksbuild.2"
     "1.33" = "v1.3.8-eksbuild.2"
+    "1.34" = "v1.3.10-eksbuild.3"
+    "1.35" = "v1.3.10-eksbuild.3"
   }
 
   # https://docs.aws.amazon.com/eks/latest/userguide/node-health.html
@@ -50,6 +62,8 @@ locals {
   eks_node_monitoring_agent_version = {
     "1.32" = "v1.4.0-eksbuild.2"
     "1.33" = "v1.4.0-eksbuild.2"
+    "1.34" = "v1.6.4-eksbuild.1"
+    "1.35" = "v1.6.4-eksbuild.1"
   }
 
   # https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html#s3-install-driver
@@ -57,6 +71,8 @@ locals {
   mountpoint_s3_csi_version = {
     "1.32" = "v2.0.0-eksbuild.1"
     "1.33" = "v2.0.0-eksbuild.1"
+    "1.34" = "v2.5.0-eksbuild.1"
+    "1.35" = "v2.5.0-eksbuild.1"
   }
 
   # https://docs.aws.amazon.com/eks/latest/userguide/metrics-server.html
@@ -64,6 +80,8 @@ locals {
   metrcis_server_version = {
     "1.32" = "v0.8.0-eksbuild.2"
     "1.33" = "v0.8.0-eksbuild.2"
+    "1.34" = "v0.8.1-eksbuild.6"
+    "1.35" = "v0.8.1-eksbuild.6"
   }
 }
 

--- a/cluster-addons.tf
+++ b/cluster-addons.tf
@@ -5,7 +5,7 @@ locals {
   vpc_cni_version = {
     "1.32" = "v1.20.1-eksbuild.3"
     "1.33" = "v1.20.1-eksbuild.3"
-    "1.34" = "v1.20.5-eksbuild.1"
+    "1.34" = "v1.21.1-eksbuild.1"
     "1.35" = "v1.21.1-eksbuild.1"
   }
 
@@ -15,7 +15,7 @@ locals {
   coredns_version = {
     "1.32" = "v1.11.4-eksbuild.22"
     "1.33" = "v1.11.4-eksbuild.22"
-    "1.34" = "v1.12.4-eksbuild.10"
+    "1.34" = "v1.13.2-eksbuild.4"
     "1.35" = "v1.13.2-eksbuild.4"
   }
 

--- a/cluster-addons.tf
+++ b/cluster-addons.tf
@@ -3,7 +3,6 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
   # aws eks describe-addon-versions --addon-name vpc-cni --region us-east-1 --output json| jq '.addons[0].addonVersions[0]'
   vpc_cni_version = {
-    "1.32" = "v1.20.1-eksbuild.3"
     "1.33" = "v1.20.1-eksbuild.3"
     "1.34" = "v1.20.5-eksbuild.1"
     "1.35" = "v1.21.1-eksbuild.1"
@@ -13,7 +12,6 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
   # aws eks describe-addon-versions --addon-name coredns | jq '.addons[0].addonVersions[0]'
   coredns_version = {
-    "1.32" = "v1.11.4-eksbuild.22"
     "1.33" = "v1.11.4-eksbuild.22"
     "1.34" = "v1.12.4-eksbuild.10"
     "1.35" = "v1.13.2-eksbuild.4"
@@ -23,7 +21,6 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
   # aws eks describe-addon-versions --addon-name kube-proxy | jq '.addons[0].addonVersions[0]'
   kube_proxy_version = {
-    "1.32" = "v1.32.6-eksbuild.8"
     "1.33" = "v1.32.6-eksbuild.8"
     "1.34" = "v1.34.6-eksbuild.2"
     "1.35" = "v1.35.3-eksbuild.2"
@@ -32,7 +29,6 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html
   # aws eks describe-addon-versions --addon-name aws-ebs-csi-driver | jq '.addons[0].addonVersions[0]'
   ebs_csi_driver_version = {
-    "1.32" = "v1.58.0-eksbuild.1"
     "1.33" = "v1.58.0-eksbuild.1"
     "1.34" = "v1.59.0-eksbuild.1"
     "1.35" = "v1.59.0-eksbuild.1"
@@ -42,7 +38,6 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/csi-snapshot-controller.html
   # aws eks describe-addon-versions --region us-east-1 --addon-name snapshot-controller | jq '.addons[0].addonVersions[0]'
   snapshot_controller = {
-    "1.32" = "v8.3.0-eksbuild.1"
     "1.33" = "v8.3.0-eksbuild.1"
     "1.34" = "v8.5.0-eksbuild.4"
     "1.35" = "v8.5.0-eksbuild.4"
@@ -51,7 +46,6 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/pod-id-agent-setup.html
   # aws eks describe-addon-versions --addon-name eks-pod-identity-agent | jq '.addons[0].addonVersions[0]'
   eks_pod_identity_agent_version = {
-    "1.32" = "v1.3.8-eksbuild.2"
     "1.33" = "v1.3.8-eksbuild.2"
     "1.34" = "v1.3.10-eksbuild.3"
     "1.35" = "v1.3.10-eksbuild.3"
@@ -60,7 +54,6 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/node-health.html
   # aws eks describe-addon-versions --addon-name eks-node-monitoring-agent | jq '.addons[0].addonVersions[0]'
   eks_node_monitoring_agent_version = {
-    "1.32" = "v1.4.0-eksbuild.2"
     "1.33" = "v1.4.0-eksbuild.2"
     "1.34" = "v1.6.4-eksbuild.1"
     "1.35" = "v1.6.4-eksbuild.1"
@@ -69,7 +62,6 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html#s3-install-driver
   # aws eks describe-addon-versions --addon-name aws-mountpoint-s3-csi-driver --region us-east-1 --output json| jq '.addons[0].addonVersions[0]'
   mountpoint_s3_csi_version = {
-    "1.32" = "v2.0.0-eksbuild.1"
     "1.33" = "v2.0.0-eksbuild.1"
     "1.34" = "v2.5.0-eksbuild.1"
     "1.35" = "v2.5.0-eksbuild.1"
@@ -78,7 +70,6 @@ locals {
   # https://docs.aws.amazon.com/eks/latest/userguide/metrics-server.html
   # aws eks describe-addon-versions --addon-name metrics-server --region us-east-1 --output json| jq '.addons[0].addonVersions[0]'
   metrcis_server_version = {
-    "1.32" = "v0.8.0-eksbuild.2"
     "1.33" = "v0.8.0-eksbuild.2"
     "1.34" = "v0.8.1-eksbuild.6"
     "1.35" = "v0.8.1-eksbuild.6"

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,11 @@ variable "region" {
 variable "cluster_version" {
   description = "The Kubernetes version to use for the cluster."
   type        = string
-  default     = "1.33"
+  default     = "1.35"
+  validation {
+    condition     = contains(["1.33", "1.34", "1.35"], var.cluster_version)
+    error_message = "Supported Kubernetes versions are: 1.33, 1.34, 1.35."
+  }
 }
 
 variable "vpc_config" {

--- a/variables.tf
+++ b/variables.tf
@@ -33,11 +33,7 @@ variable "region" {
 variable "cluster_version" {
   description = "The Kubernetes version to use for the cluster."
   type        = string
-  default     = "1.35"
-  validation {
-    condition     = contains(["1.33", "1.34", "1.35"], var.cluster_version)
-    error_message = "Supported Kubernetes versions are: 1.33, 1.34, 1.35."
-  }
+  default     = "1.33"
 }
 
 variable "vpc_config" {


### PR DESCRIPTION
Requestor/Issue:
INFRA-6314

Tested (yes/no):
yes (addon versions fetched from AWS API via describe-addon-versions --query defaultVersion, terraform fmt -check passed)

Description/Why:
EKS upgrade initiative (1.33 -> 1.35). Adds 1.34 and 1.35 entries to all 9 addon version maps in cluster-addons.tf so infrastructure workspaces can set cluster_version = "1.34" or "1.35" without hitting a missing key error. 

Intentionally adding new versions only without removing 1.32 or changing defaults - keeps this as a non-breaking patch release. Cleanup (dropping 1.32, updating default, adding validation) will follow in a separate release once clusters are upgraded.

AI usage/prompt(s) (if applicable):
Claude
Fetched addon versions from AWS API, applied changes across all addon maps
