### PR TITLE
fix: gateway_api validations compat with older Terraform versions

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -861,7 +861,7 @@ variable "gateway_api_external_alb_sg_rules" {
 
   validation {
     condition = var.gateway_api_external_alb_sg_rules == null || alltrue([
-      for r in var.gateway_api_external_alb_sg_rules :
+      for r in coalesce(var.gateway_api_external_alb_sg_rules, []) :
       can(r.port) && (can(r.cidr_blocks) || can(r.security_groups))
     ])
     error_message = "Each rule must have a 'port' and at least one of 'cidr_blocks' or 'security_groups'."
@@ -875,7 +875,7 @@ variable "gateway_api_internal_alb_sg_rules" {
 
   validation {
     condition = var.gateway_api_internal_alb_sg_rules == null || alltrue([
-      for r in var.gateway_api_internal_alb_sg_rules :
+      for r in coalesce(var.gateway_api_internal_alb_sg_rules, []) :
       can(r.port) && (can(r.cidr_blocks) || can(r.security_groups))
     ])
     error_message = "Each rule must have a 'port' and at least one of 'cidr_blocks' or 'security_groups'."
@@ -889,7 +889,7 @@ variable "gateway_api_external_nlb_sg_rules" {
 
   validation {
     condition = var.gateway_api_external_nlb_sg_rules == null || alltrue([
-      for r in var.gateway_api_external_nlb_sg_rules :
+      for r in coalesce(var.gateway_api_external_nlb_sg_rules, []) :
       can(r.port) && (can(r.cidr_blocks) || can(r.ipv6_cidr_blocks) || can(r.security_groups))
     ])
     error_message = "Each rule must have a 'port' and at least one of 'cidr_blocks', 'ipv6_cidr_blocks', or 'security_groups'."
@@ -903,7 +903,7 @@ variable "gateway_api_internal_nlb_sg_rules" {
 
   validation {
     condition = var.gateway_api_internal_nlb_sg_rules == null || alltrue([
-      for r in var.gateway_api_internal_nlb_sg_rules :
+      for r in coalesce(var.gateway_api_internal_nlb_sg_rules, []) :
       can(r.port) && (can(r.cidr_blocks) || can(r.ipv6_cidr_blocks) || can(r.security_groups))
     ])
     error_message = "Each rule must have a 'port' and at least one of 'cidr_blocks', 'ipv6_cidr_blocks', or 'security_groups'."
@@ -1072,7 +1072,7 @@ variable "gateway_api_lb_name_prefix" {
   default     = null
 
   validation {
-    condition     = var.gateway_api_lb_name_prefix == null || (length(var.gateway_api_lb_name_prefix) <= 21 && can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", var.gateway_api_lb_name_prefix)))
+    condition     = var.gateway_api_lb_name_prefix == null || (length(coalesce(var.gateway_api_lb_name_prefix, "")) <= 21 && can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", var.gateway_api_lb_name_prefix)))
     error_message = "gateway_api_lb_name_prefix must be <= 21 characters (to fit 32-char LB name limit with suffix) and contain only lowercase alphanumeric characters or hyphens."
   }
 }


### PR DESCRIPTION
## Requestor/Issue:
INFRA-6340

## Tested (yes/no):
yes (terraform plan in TF Cloud passed without errors)

## Description/Why:
`ampc-hnsw-setup` uses terraform-aws-eks and runs in TF Cloud workspaces with an older Terraform version that does not support short-circuit evaluation of `||` in variable validations. 

Note: this fix will only be bumped in `ampc-hnsw-setup` module used by WF TF Cloud workspaces - no need to release it in the infra repo TFE workspaces which run a newer TF version.