### PR TITLE
fix: gateway_api validations compat with older Terraform versions

### DIFF
--- a/tests/kubernetes-gateway-api.tftest.hcl
+++ b/tests/kubernetes-gateway-api.tftest.hcl
@@ -360,6 +360,21 @@ run "gateway_api_k8s_manifests_internal_enabled" {
 }
 
 # =============================================================================
+# Test: gateway_api_lb_name_prefix empty string fails validation (not eval error)
+# =============================================================================
+run "gateway_api_lb_name_prefix_empty_string_fails_validation" {
+  command = plan
+
+  variables {
+    gateway_api_lb_name_prefix = ""
+  }
+
+  expect_failures = [
+    var.gateway_api_lb_name_prefix,
+  ]
+}
+
+# =============================================================================
 # Test: SSL policy derived from TLS listener version
 # =============================================================================
 run "gateway_api_ssl_policy_mapping" {

--- a/variables.tf
+++ b/variables.tf
@@ -1072,7 +1072,7 @@ variable "gateway_api_lb_name_prefix" {
   default     = null
 
   validation {
-    condition     = var.gateway_api_lb_name_prefix == null || (length(coalesce(var.gateway_api_lb_name_prefix, "")) <= 21 && can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", var.gateway_api_lb_name_prefix)))
+    condition     = var.gateway_api_lb_name_prefix == null || try(length(var.gateway_api_lb_name_prefix) <= 21 && can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", var.gateway_api_lb_name_prefix)), false)
     error_message = "gateway_api_lb_name_prefix must be <= 21 characters (to fit 32-char LB name limit with suffix) and contain only lowercase alphanumeric characters or hyphens."
   }
 }


### PR DESCRIPTION
## Requestor/Issue:
INFRA-6340

## Tested (yes/no):
no - required bump intermediate module first to check TF plan

## Description/Why:
Follow-up fix: replace coalesce with try() for gateway_api_lb_name_prefix validation - coalesce(null, "") fails because coalesce skips both null and empty strings. try() handles this correctly on all Terraform versions.