### PR TITLE
chore: drop pull_request trigger from release-drafter workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
Requestor/Issue: @tomasz.charewicz (no ticket provided)

Tested (yes/no): no (workflow-only change; preemptive — same fix just applied in worldcoin/terraform-mongo-modules#42 after the failure manifested there)

Description/Why:
Aligns `.github/workflows/release.yml` with the convention used across every other `worldcoin/terraform-*` repo (alb, iam, modules, nlb, s3-bucket, secret-manager, vpc, cf-modules, github-modules, okta-modules — all use `push: main` only). Currently only this repo and `terraform-mongo-modules` had a `pull_request` trigger; mongo-modules just got fixed.

The repo's release-drafter config uses `filter-by-commitish: true` (the standard across the fleet). With release-drafter v7 + that filter, the `pull_request` trigger causes the action to:
1. Filter out all existing releases (none target `refs/pull/N/merge`).
2. Fall into the "create new release" path.
3. Try to create the release with `target_commitish = refs/pull/N/merge`.
4. GitHub REST API rejects: `Validation Failed: {"resource":"Release","code":"invalid","field":"target_commitish"}`.

This repo is still pinned to release-drafter v6 (which is lenient), so PRs pass today — but the next dependabot v6 → v7 bump would break exactly like `terraform-mongo-modules#40` did. Removing the `pull_request` trigger now means the eventual major upgrade can land cleanly.