### PR TITLE
chore: pin all GitHub Actions to SHAs at latest versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,11 +14,11 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         name: Checkout source code
 
       - name: Render terraform docs inside the README.md and push changes back to main branch
-        uses: terraform-docs/gh-actions@v1.3.0
+        uses: terraform-docs/gh-actions@6de6da0cefcc6b4b7a5cbea4d79d97060733093c
 
       # fix to terraform-docs action change ownership of files
       - name: Update ownership of files
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check-existence.outputs.branches == ''
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           title: Update terraform docs
           branch: generated-docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/relyance-sci.yml
+++ b/.github/workflows/relyance-sci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Run Relyance SCI
-        uses: worldcoin/gh-actions-public/relyance@main
+        uses: worldcoin/gh-actions-public/relyance@876250d5972de5174d94001b6035cf774cf54685
         # More information: https://github.com/worldcoin/gh-actions-public/tree/main/relyance
         with:
           secrets-dpp-sci-key: ${{ secrets.DPP_SCI_KEY }}

--- a/.github/workflows/terraform-test.yml
+++ b/.github/workflows/terraform-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: terraform test
         uses: dflook/terraform-test@58481fc46588861db38966e076b8481402817b91

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         name: Checkout source code
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         name: Cache plugin dir
         with:
           path: ~/.tflint.d/plugins
           key: tflint-${{ hashFiles('.tflint.hcl') }}
 
-      - uses: terraform-linters/setup-tflint@v4
+      - uses: terraform-linters/setup-tflint@b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93
         name: Setup TFLint
         with:
           tflint_version: v0.42.2


### PR DESCRIPTION
Requestor/Issue: @tomasz.charewicz (no ticket provided)

Tested (yes/no): no (workflow-only change; verification is observing CI on this PR — tflint, terraform-test, trivy, docs, release jobs all need to come up green)

Description/Why:
Eliminates floating refs (`@master`, `@main`) and version-tag pins (`@v4`, `@v6`, `@v1.3.0`, ...) in favor of SHA pins on every `uses:` line in `.github/workflows/`. SHA pinning prevents tag-rewrite supply-chain attacks — a compromised upstream maintainer (or an attacker with push access) can re-point a tag at malicious code; a SHA is content-addressed and can't be silently swapped.

Before this PR: 15 `uses:` references — 7 SHA-pinned, 8 not. After: 15/15 SHA-pinned.

Each ref upgraded to its current latest release in the same commit:

| Action | From | To |
|---|---|---|
| actions/checkout | v4 / master | v6.0.2 (`de0fac2`) |
| actions/cache | v4 | v5.0.5 (`27d5ce7`) |
| peter-evans/create-pull-request | v7 | v8.1.1 (`5f6978f`) |
| release-drafter/release-drafter | v6 | v7.3.0 (`c2e2804`) |
| terraform-linters/setup-tflint | v4 | v6.2.2 (`b480b8f`) |
| terraform-docs/gh-actions | v1.3.0 | v1.4.1 (`6de6da0`) |
| worldcoin/gh-actions-public/relyance | main | `876250d` |

Notes:
- `actions/checkout@master` in `terraform-test.yml` was the highest-risk item (mutable branch ref, also points at a stale branch name — `actions/checkout` renamed default to `main`). Aligned with the same v6.0.2 SHA already used in `trivy.yml`.
- `release-drafter` v6 → v7 is safe to land now because PR #109 (just merged) removed the `pull_request` trigger from `release.yml`. Without that prior fix, v7 would have failed with the `target_commitish` API error — same issue we just fixed in `terraform-mongo-modules#42`.
- `terraform-update-modules-public-pull.yaml` retained its existing SHA pins (older versions but already pinned) to keep this PR scoped to fixing floating/tag refs. Future dependabot bumps will update those SHAs.
- The major-version bumps in this PR match what dependabot would propose in 5–6 separate PRs over the next weekly cycle — consolidating them here saves the triage round trips and gets SHA-pinning + version updates in one shot.