### PR TITLE
fix: allow all internal networks (10.0.0.0/8) on gw-int ALB and NLB INFRA-6480

### DIFF
--- a/kubernetes-gw-int-alb.tf
+++ b/kubernetes-gw-int-alb.tf
@@ -4,9 +4,9 @@ locals {
   gateway_api_internal_alb_sg_rules = var.gateway_api_internal_alb_sg_rules != null ? var.gateway_api_internal_alb_sg_rules : concat(
     [
       {
-        description = "Allow HTTPS from VPC"
+        description = "Allow HTTPS from all internal networks"
         port        = 443
-        cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
+        cidr_blocks = ["10.0.0.0/8"]
       },
     ],
     data.aws_vpc.cluster_vpc.ipv6_cidr_block != "" ? [

--- a/kubernetes-gw-int-nlb.tf
+++ b/kubernetes-gw-int-nlb.tf
@@ -4,24 +4,24 @@ locals {
   gateway_api_internal_nlb_sg_rules = var.gateway_api_internal_nlb_sg_rules != null ? var.gateway_api_internal_nlb_sg_rules : concat(
     [
       {
-        description = "allow http from VPC"
+        description = "Allow HTTP from all internal networks"
         port        = 80
-        cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
+        cidr_blocks = ["10.0.0.0/8"]
       },
       {
-        description = "allow https from VPC"
+        description = "Allow HTTPS from all internal networks"
         port        = 443
-        cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
+        cidr_blocks = ["10.0.0.0/8"]
       },
     ],
     data.aws_vpc.cluster_vpc.ipv6_cidr_block != "" ? [
       {
-        description      = "allow http from VPC (IPv6)"
+        description      = "Allow HTTP from VPC (IPv6)"
         port             = 80
         ipv6_cidr_blocks = [data.aws_vpc.cluster_vpc.ipv6_cidr_block]
       },
       {
-        description      = "allow https from VPC (IPv6)"
+        description      = "Allow HTTPS from VPC (IPv6)"
         port             = 443
         ipv6_cidr_blocks = [data.aws_vpc.cluster_vpc.ipv6_cidr_block]
       },

--- a/variables.tf
+++ b/variables.tf
@@ -869,7 +869,7 @@ variable "gateway_api_external_alb_sg_rules" {
 }
 
 variable "gateway_api_internal_alb_sg_rules" {
-  description = "Override LB security group ingress rules for the internal Gateway API ALB. When null, allows HTTPS from VPC CIDR."
+  description = "Override LB security group ingress rules for the internal Gateway API ALB. When null, allows HTTPS from all internal networks (10.0.0.0/8)."
   type        = any
   default     = null
 
@@ -897,7 +897,7 @@ variable "gateway_api_external_nlb_sg_rules" {
 }
 
 variable "gateway_api_internal_nlb_sg_rules" {
-  description = "Override LB security group ingress rules for the internal Gateway API NLB. When null, allows ports 80 and 443 from VPC CIDR."
+  description = "Override LB security group ingress rules for the internal Gateway API NLB. When null, allows ports 80 and 443 from all internal networks (10.0.0.0/8)."
   type        = any
   default     = null
 


### PR DESCRIPTION
Requestor/Issue:
@daniel.fenert INFRA-6480

Tested (yes/no):
yes, PR: https://github.com/worldcoin/infrastructure/pull/41714/changes, TFE plan: https://tfe.worldcoin.dev/app/TFH/aggregated-commit-statuses/acs-qXTV3tc9V7ceCNbo

Description/Why:
The default security group rules for `gw-int-alb` and `gw-int-nlb` only allow HTTPS from the local VPC CIDR. This blocks cross-VPC traffic from peered VPCs — a regression from traefik-internal NLBs which allowed 0/0

Since all VPCs use CIDRs within `10.0.0.0/8` (per `terraform-aws-vpc` `region_cidrs` and `region_cidrs_2`), this widens the default to `10.0.0.0/8` for both `gw-int-alb` (HTTPS) and `gw-int-nlb` (HTTP + HTTPS). Clusters that override `gateway_api_internal_alb_sg_rules` or `gateway_api_internal_nlb_sg_rules` are unaffected.

AI usage/prompt(s) (if applicable):
GitHub Copilot (Claude) — diagnosed the NLB→ALB SG behavioral difference and generated the CIDR change.
