### PR TITLE
INFRA-6484: drop SSH for public module sources; unblock CI test

### DIFF
--- a/.github/workflows/terraform-test.yml
+++ b/.github/workflows/terraform-test.yml
@@ -14,5 +14,3 @@ jobs:
 
       - name: terraform test
         uses: dflook/terraform-test@58481fc46588861db38966e076b8481402817b91
-        env:
-          TERRAFORM_SSH_KEY: ${{ secrets.SSH_KEY_GITHUB_AUTOMATION }}

--- a/.github/workflows/terraform-test.yml
+++ b/.github/workflows/terraform-test.yml
@@ -14,3 +14,10 @@ jobs:
 
       - name: terraform test
         uses: dflook/terraform-test@58481fc46588861db38966e076b8481402817b91
+        env:
+          # Rewrite SSH refs to HTTPS so transitive worldcoin/* module
+          # sources (e.g. inside terraform-datadog-kubernetes) clone
+          # anonymously without an SSH key.
+          TERRAFORM_PRE_RUN: |
+            git config --global --add url."https://github.com/".insteadOf "git@github.com:"
+            git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"

--- a/datadog-user.tf
+++ b/datadog-user.tf
@@ -1,7 +1,7 @@
 module "datadog_monitoring_for_user" {
   count = var.monitoring_user_workload_notification_channel != "" ? 1 : 0
 
-  source = "git@github.com:worldcoin/terraform-datadog-kubernetes?ref=v1.2.3"
+  source = "git::https://github.com/worldcoin/terraform-datadog-kubernetes?ref=v1.2.3"
 
   notification_channel = var.monitoring_user_workload_notification_channel
   service              = format("EKS %s", var.cluster_name)

--- a/datadog.tf
+++ b/datadog.tf
@@ -14,7 +14,7 @@ locals {
 module "datadog_monitoring" {
   count = var.monitoring_enabled ? 1 : 0
 
-  source = "git@github.com:worldcoin/terraform-datadog-kubernetes?ref=v1.2.3"
+  source = "git::https://github.com/worldcoin/terraform-datadog-kubernetes?ref=v1.2.3"
 
   notification_channel = var.monitoring_notification_channel
   service              = format("EKS %s", var.cluster_name)

--- a/kubernetes-gw-ext-alb.tf
+++ b/kubernetes-gw-ext-alb.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 module "gateway_api_external_alb" {
-  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=v1.6.0"
+  source   = "git::https://github.com/worldcoin/terraform-aws-alb.git?ref=v1.6.0"
   for_each = var.gateway_api_external_enabled ? toset([local.gateway_api_external_alb_name]) : []
 
   name_suffix  = each.key

--- a/kubernetes-gw-ext-nlb.tf
+++ b/kubernetes-gw-ext-nlb.tf
@@ -26,7 +26,7 @@ locals {
 }
 
 module "gateway_api_external_nlb" {
-  source = "git@github.com:worldcoin/terraform-aws-nlb.git?ref=v1.5.0"
+  source = "git::https://github.com/worldcoin/terraform-aws-nlb.git?ref=v1.5.0"
 
   for_each = var.gateway_api_external_enabled ? toset([local.gateway_api_external_nlb_name]) : []
 

--- a/kubernetes-gw-int-alb.tf
+++ b/kubernetes-gw-int-alb.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 module "gateway_api_internal_alb" {
-  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=v1.6.0"
+  source   = "git::https://github.com/worldcoin/terraform-aws-alb.git?ref=v1.6.0"
   for_each = var.gateway_api_internal_enabled ? toset([local.gateway_api_internal_alb_name]) : []
 
   name_suffix  = each.key

--- a/kubernetes-gw-int-nlb.tf
+++ b/kubernetes-gw-int-nlb.tf
@@ -30,7 +30,7 @@ locals {
 }
 
 module "gateway_api_internal_nlb" {
-  source = "git@github.com:worldcoin/terraform-aws-nlb.git?ref=v1.5.0"
+  source = "git::https://github.com/worldcoin/terraform-aws-nlb.git?ref=v1.5.0"
 
   for_each = var.gateway_api_internal_enabled ? toset([local.gateway_api_internal_nlb_name]) : []
 

--- a/kubernetes-traefik-external.tf
+++ b/kubernetes-traefik-external.tf
@@ -93,7 +93,7 @@ resource "kubernetes_ingress_v1" "treafik_ingress" {
 }
 
 module "alb" {
-  source   = "git@github.com:worldcoin/terraform-aws-alb.git?ref=v1.6.0"
+  source   = "git::https://github.com/worldcoin/terraform-aws-alb.git?ref=v1.6.0"
   for_each = var.external_alb_enabled ? toset([local.external_alb_name]) : []
 
   # because of lenght limitation of LB name we need to remove prefix treafik from internal NLB

--- a/kubernetes-traefik-internal.tf
+++ b/kubernetes-traefik-internal.tf
@@ -70,7 +70,7 @@ resource "kubernetes_service_v1" "traefik_nlb" {
 }
 
 module "nlb" {
-  source = "git@github.com:worldcoin/terraform-aws-nlb.git?ref=v1.5.0"
+  source = "git::https://github.com/worldcoin/terraform-aws-nlb.git?ref=v1.5.0"
 
   for_each = var.internal_nlb_enabled ? toset([local.internal_nlb_name]) : []
 


### PR DESCRIPTION
Requestor/Issue: [INFRA-6484](https://linear.app/worldcoin/issue/INFRA-6484/terraform-aws-eks-drop-ssh-for-public-module-sources-unblock-ci-test)

Tested (yes/no): yes (\`terraform fmt -check\` clean; CI \`test\` job result on this PR is the real validation)

Description/Why:
The CI \`test\` job has been failing on every PR with \`Load key "/.ssh/id_rsa": invalid format\` when cloning \`worldcoin/terraform-aws-alb\` and \`worldcoin/terraform-aws-nlb\` via SSH. Three open Dependabot PRs (#112, #113, #114) are blocked by this even though their own diffs are clean.

Root cause is the repo-scoped \`SSH_KEY_GITHUB_AUTOMATION\` secret value no longer parsing as a valid private key. Rather than rotate the secret, this PR removes the need for it entirely: all worldcoin/* modules referenced by this repo are PUBLIC, so they can be fetched over anonymous HTTPS.

Visibility check:
- \`worldcoin/terraform-aws-eks\` — PUBLIC
- \`worldcoin/terraform-aws-alb\` — PUBLIC
- \`worldcoin/terraform-aws-nlb\` — PUBLIC
- \`worldcoin/terraform-datadog-kubernetes\` — PUBLIC

Changes:
- 8 \`.tf\` files: \`source = "git@github.com:worldcoin/…"\` → \`source = "git::https://github.com/worldcoin/…"\`. Refs (\`v1.5.0\`, \`v1.6.0\`, \`v1.2.3\`) unchanged.
- \`.github/workflows/terraform-test.yml\`: drop the \`TERRAFORM_SSH_KEY\` env block from the \`dflook/terraform-test\` step.

The \`SSH_KEY_GITHUB_AUTOMATION\` secret itself is left in place — removing it should be done after confirming no other reference (org-scoped or otherwise). Tracked as a follow-up in the linked ticket.

Downstream impact: consumers of this module in \`worldcoin/infrastructure\` are unaffected. The transitive HTTPS references are resolved per-module at \`terraform init\`, independent of how this parent module is fetched by the consuming workspace.

AI usage/prompt(s) (if applicable):
- Claude Code (Opus 4.7) — diagnosed the CI failure root cause from the failing job logs, identified that the modules are public and SSH is unnecessary, drafted the \`source\` rewrites and workflow edit, and wrote this PR body. Reviewed and accepted by the requestor.