### PR TITLE
feat: add use_private_subnets toggle to reduce NAT gateway costs

### DIFF
--- a/eks-node-group.tf
+++ b/eks-node-group.tf
@@ -54,7 +54,7 @@ resource "aws_eks_node_group" "al2023" {
   node_group_name = trimsuffix(substr(local.al2023_name, 0, 63), "-")
   node_role_arn   = aws_iam_role.node.arn
   cluster_name    = aws_eks_cluster.this.name
-  subnet_ids      = var.vpc_config.private_subnets
+  subnet_ids      = var.use_private_subnets ? var.vpc_config.private_subnets : var.vpc_config.public_subnets
 
 
   # https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#API_Nodegroup_Contents

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "vpc_config" {
   }
 }
 
+variable "use_private_subnets" {
+  description = "Set to `true` to place EKS node groups in private subnets, `false` to use public subnets."
+  type        = bool
+  default     = true
+}
+
 variable "vpc_cni_version_override" {
   description = "The version of the VPC CNI plugin to use. If not specified, the default version for the cluster version will be used."
   type        = string


### PR DESCRIPTION
Requestor/Issue: cost optimization initiative
Tested (yes/no): no
Description/Why: NAT gateway data-processing fees are significant at scale. This adds a `use_private_subnets` toggle (default `true`, preserving existing behaviour) so node groups can be placed in public subnets when private networking is not required — eliminating NAT gateway charges for that traffic.
https://tfe.worldcoin.dev/app/TFH/workspaces/public-self-hosted-runners-prod-eu-central-1/runs/run-26J8cZmm9DKCk9W4