### PR TITLE
INFRA-6516: reduce cloudwatch eks log group retention from 30d to 1d

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "this" {
   name              = "/aws/eks/${var.cluster_name}/cluster"
   kms_key_id        = aws_kms_key.this.arn
-  retention_in_days = 30
+  retention_in_days = 1
 }


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-6516/change-retention-of-kubernetesaudit-logs-in-cloudwatch-to-1d
Tested (yes/no): yes
Description/Why: EKS control plane logs (audit, api, authenticator, scheduler, controllerManager) are forwarded to Datadog via dd-forwarder, so long CloudWatch retention is unnecessary. Reducing retention from 30d to 1d cuts CloudWatch storage costs