### PR TITLE
feat: add vector s3 pod identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -861,6 +861,7 @@ To remove the cluster you have to:
 | <a name="input_vpc_cni_version_override"></a> [vpc\_cni\_version\_override](#input\_vpc\_cni\_version\_override) | The version of the VPC CNI plugin to use. If not specified, the default version for the cluster version will be used. | `string` | `""` | no |
 | <a name="input_vpc_cni_warm_eni_target"></a> [vpc\_cni\_warm\_eni\_target](#input\_vpc\_cni\_warm\_eni\_target) | Number of ENIs to keep warm for each node to speed up pod scheduling | `string` | `"1"` | no |
 | <a name="input_vpc_cni_warm_ip_target"></a> [vpc\_cni\_warm\_ip\_target](#input\_vpc\_cni\_warm\_ip\_target) | Number of IPs to keep warm for each node to speed up pod scheduling | `string` | `"4"` | no |
+| <a name="input_vector_s3_bucket_arns"></a> [vector\_s3\_bucket\_arns](#input\_vector\_s3\_bucket\_arns) | S3 bucket ARNs Vector is allowed to write logs to. Empty disables Vector IAM role and pod identity association. | `list(string)` | <pre>[<br>  "arn:aws:s3:::wld-log-archive"<br>]</pre> | no |
 | <a name="input_vpc_config"></a> [vpc\_config](#input\_vpc\_config) | VPC configuration from aws/vps module | <pre>object({<br>    vpc_id          = string<br>    private_subnets = list(string)<br>    public_subnets  = list(string)<br>  })</pre> | n/a | yes |
 | <a name="input_wafv2_arn"></a> [wafv2\_arn](#input\_wafv2\_arn) | The ARN of the WAFv2 WebACL to associate with the ALB | `string` | `""` | no |
 

--- a/README.md
+++ b/README.md
@@ -623,14 +623,14 @@ To remove the cluster you have to:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alb"></a> [alb](#module\_alb) | git@github.com:worldcoin/terraform-aws-alb.git | v1.5.1 |
-| <a name="module_datadog_monitoring"></a> [datadog\_monitoring](#module\_datadog\_monitoring) | git@github.com:worldcoin/terraform-datadog-kubernetes | v1.2.3 |
-| <a name="module_datadog_monitoring_for_user"></a> [datadog\_monitoring\_for\_user](#module\_datadog\_monitoring\_for\_user) | git@github.com:worldcoin/terraform-datadog-kubernetes | v1.2.3 |
-| <a name="module_gateway_api_external_alb"></a> [gateway\_api\_external\_alb](#module\_gateway\_api\_external\_alb) | git@github.com:worldcoin/terraform-aws-alb.git | v1.5.1 |
-| <a name="module_gateway_api_external_nlb"></a> [gateway\_api\_external\_nlb](#module\_gateway\_api\_external\_nlb) | git@github.com:worldcoin/terraform-aws-nlb.git | v1.4.0 |
-| <a name="module_gateway_api_internal_alb"></a> [gateway\_api\_internal\_alb](#module\_gateway\_api\_internal\_alb) | git@github.com:worldcoin/terraform-aws-alb.git | v1.5.1 |
-| <a name="module_gateway_api_internal_nlb"></a> [gateway\_api\_internal\_nlb](#module\_gateway\_api\_internal\_nlb) | git@github.com:worldcoin/terraform-aws-nlb.git | v1.4.0 |
-| <a name="module_nlb"></a> [nlb](#module\_nlb) | git@github.com:worldcoin/terraform-aws-nlb.git | v1.4.0 |
+| <a name="module_alb"></a> [alb](#module\_alb) | <git@github.com>:worldcoin/terraform-aws-alb.git | v1.5.1 |
+| <a name="module_datadog_monitoring"></a> [datadog\_monitoring](#module\_datadog\_monitoring) | <git@github.com>:worldcoin/terraform-datadog-kubernetes | v1.2.3 |
+| <a name="module_datadog_monitoring_for_user"></a> [datadog\_monitoring\_for\_user](#module\_datadog\_monitoring\_for\_user) | <git@github.com>:worldcoin/terraform-datadog-kubernetes | v1.2.3 |
+| <a name="module_gateway_api_external_alb"></a> [gateway\_api\_external\_alb](#module\_gateway\_api\_external\_alb) | <git@github.com>:worldcoin/terraform-aws-alb.git | v1.5.1 |
+| <a name="module_gateway_api_external_nlb"></a> [gateway\_api\_external\_nlb](#module\_gateway\_api\_external\_nlb) | <git@github.com>:worldcoin/terraform-aws-nlb.git | v1.4.0 |
+| <a name="module_gateway_api_internal_alb"></a> [gateway\_api\_internal\_alb](#module\_gateway\_api\_internal\_alb) | <git@github.com>:worldcoin/terraform-aws-alb.git | v1.5.1 |
+| <a name="module_gateway_api_internal_nlb"></a> [gateway\_api\_internal\_nlb](#module\_gateway\_api\_internal\_nlb) | <git@github.com>:worldcoin/terraform-aws-nlb.git | v1.4.0 |
+| <a name="module_nlb"></a> [nlb](#module\_nlb) | <git@github.com>:worldcoin/terraform-aws-nlb.git | v1.4.0 |
 
 ## Resources
 
@@ -856,7 +856,7 @@ To remove the cluster you have to:
 | <a name="input_vpc_cni_enable_network_policy"></a> [vpc\_cni\_enable\_network\_policy](#input\_vpc\_cni\_enable\_network\_policy) | Enable Kubernetes NetworkPolicy enforcement via the VPC CNI node agent | `bool` | `false` | no |
 | <a name="input_vpc_cni_enable_pod_eni"></a> [vpc\_cni\_enable\_pod\_eni](#input\_vpc\_cni\_enable\_pod\_eni) | Enable pod ENI support | `bool` | `false` | no |
 | <a name="input_vpc_cni_enable_prefix_delegation"></a> [vpc\_cni\_enable\_prefix\_delegation](#input\_vpc\_cni\_enable\_prefix\_delegation) | Enable prefix delegation for IPv6, allocate IPs in /28 blocks (instead of all at once) | `bool` | `false` | no |
-| <a name="input_vpc_cni_external_snat"></a> [vpc\_cni\_external\_snat](#input\_vpc\_cni\_external\_snat) | Needed to enable cross-vpc pod-to-pod communication - see: https://github.com/aws/amazon-vpc-cni-k8s?tab=readme-ov-file#aws_vpc_k8s_cni_externalsnat | `string` | `false` | no |
+| <a name="input_vpc_cni_external_snat"></a> [vpc\_cni\_external\_snat](#input\_vpc\_cni\_external\_snat) | Needed to enable cross-vpc pod-to-pod communication - see: <https://github.com/aws/amazon-vpc-cni-k8s?tab=readme-ov-file#aws_vpc_k8s_cni_externalsnat> | `string` | `false` | no |
 | <a name="input_vpc_cni_pod_security_group_enforcing_mode"></a> [vpc\_cni\_pod\_security\_group\_enforcing\_mode](#input\_vpc\_cni\_pod\_security\_group\_enforcing\_mode) | Set pod security group enforcing mode | `string` | `"standard"` | no |
 | <a name="input_vpc_cni_version_override"></a> [vpc\_cni\_version\_override](#input\_vpc\_cni\_version\_override) | The version of the VPC CNI plugin to use. If not specified, the default version for the cluster version will be used. | `string` | `""` | no |
 | <a name="input_vpc_cni_warm_eni_target"></a> [vpc\_cni\_warm\_eni\_target](#input\_vpc\_cni\_warm\_eni\_target) | Number of ENIs to keep warm for each node to speed up pod scheduling | `string` | `"1"` | no |

--- a/iam-vector.tf
+++ b/iam-vector.tf
@@ -1,0 +1,68 @@
+data "aws_iam_policy_document" "vector_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+  }
+}
+
+resource "aws_iam_role" "vector" {
+  count              = length(var.vector_s3_bucket_arns) > 0 ? 1 : 0
+  name               = trimsuffix(substr("vector-${var.cluster_name}", 0, 63), "-")
+  assume_role_policy = data.aws_iam_policy_document.vector_assume_role.json
+  path               = "/system/"
+}
+
+data "aws_iam_policy_document" "vector" {
+  count = length(var.vector_s3_bucket_arns) > 0 ? 1 : 0
+
+  statement {
+    sid    = "AllowVectorToWriteObjects"
+    effect = "Allow"
+
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+    ]
+
+    resources = formatlist("%s/*", var.vector_s3_bucket_arns)
+  }
+
+  statement {
+    sid    = "AllowVectorToInspectBucket"
+    effect = "Allow"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+    ]
+
+    resources = var.vector_s3_bucket_arns
+  }
+}
+
+resource "aws_iam_role_policy" "vector" {
+  count  = length(var.vector_s3_bucket_arns) > 0 ? 1 : 0
+  name   = trimsuffix(substr("vector-${var.cluster_name}", 0, 63), "-")
+  role   = aws_iam_role.vector[0].id
+  policy = data.aws_iam_policy_document.vector[0].json
+}
+
+resource "aws_eks_pod_identity_association" "vector" {
+  count = length(var.vector_s3_bucket_arns) > 0 ? 1 : 0
+
+  cluster_name    = aws_eks_cluster.this.id
+  namespace       = "vector"
+  service_account = "vector"
+  role_arn        = aws_iam_role.vector[0].arn
+}

--- a/tests/vector.tftest.hcl
+++ b/tests/vector.tftest.hcl
@@ -1,0 +1,69 @@
+mock_provider "aws" {
+  source = "./tests/mocks/aws"
+}
+
+mock_provider "datadog" {}
+mock_provider "cloudflare" {}
+mock_provider "kubernetes" {
+  source = "./tests/mocks/kubernetes"
+}
+
+run "vector_iam_enabled_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(aws_iam_role.vector) == 1
+    error_message = "Vector IAM role should be created by default."
+  }
+
+  assert {
+    condition     = length(aws_eks_pod_identity_association.vector) == 1
+    error_message = "Vector pod identity association should be created by default."
+  }
+}
+
+run "vector_iam_disabled_when_bucket_arns_empty" {
+  command = plan
+
+  variables {
+    vector_s3_bucket_arns = []
+  }
+
+  assert {
+    condition     = length(aws_iam_role.vector) == 0
+    error_message = "Vector IAM role should not be created when vector_s3_bucket_arns is empty."
+  }
+
+  assert {
+    condition     = length(aws_eks_pod_identity_association.vector) == 0
+    error_message = "Vector pod identity association should not be created when vector_s3_bucket_arns is empty."
+  }
+}
+
+run "vector_iam_enabled_with_custom_bucket" {
+  command = plan
+
+  variables {
+    vector_s3_bucket_arns = ["arn:aws:s3:::custom-log-archive"]
+  }
+
+  assert {
+    condition     = length(aws_iam_role.vector) == 1
+    error_message = "Vector IAM role should be created when vector_s3_bucket_arns is set."
+  }
+
+  assert {
+    condition     = aws_iam_role.vector[0].name == "vector-eks-test"
+    error_message = "Vector IAM role should be named from the cluster name."
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.vector[0].namespace == "vector"
+    error_message = "Vector pod identity association should use the vector namespace."
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.vector[0].service_account == "vector"
+    error_message = "Vector pod identity association should use the vector service account."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -233,6 +233,17 @@ variable "alb_logs_bucket_id" {
   }
 }
 
+variable "vector_s3_bucket_arns" {
+  description = "S3 bucket ARNs Vector is allowed to write logs to. Empty disables Vector IAM role and pod identity association."
+  type        = list(string)
+  default     = ["arn:aws:s3:::wld-log-archive"]
+
+  validation {
+    condition     = alltrue([for arn in var.vector_s3_bucket_arns : can(regex("^arn:aws:s3:::[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$", arn))])
+    error_message = "Vector S3 bucket ARNs must be valid S3 bucket ARNs."
+  }
+}
+
 variable "traefik_nlb_service_ports" {
   description = "(Deprecated: use internal_nlb_service_ports) List of additional ports for traefik k8s service"
   type = list(object({


### PR DESCRIPTION
Requestor/Issue:
INFRA-6535

Tested (yes/no):
yes (`terraform fmt -check .`; `terraform test -filter=tests/vector.tftest.hcl`)

Description/Why:
Vector needs a reusable EKS pod identity so cluster-apps can write Kubernetes logs to the central `wld-log-archive` bucket without duplicating IAM roles and associations in every infrastructure workspace.

This adds a `/system/vector-<cluster>` IAM role, inline S3 write/list policy, and EKS pod identity association for the `vector/vector` service account. The new `vector_s3_bucket_arns` input defaults to `arn:aws:s3:::wld-log-archive`, while callers can set `[]` to disable it or provide a custom bucket list.

AI usage/prompt(s) (if applicable):
GitHub Copilot — "Add default wld-logs-archive arn so we dont have to copy it on each eks config"
