### PR TITLE
[codex] INFRA-6654 add env tag

### DIFF
--- a/eks-node-group.tf
+++ b/eks-node-group.tf
@@ -34,6 +34,7 @@ resource "aws_launch_template" "al2023" {
     tags = {
       Name              = local.al2023_name
       KubernetesCluster = var.cluster_name
+      env               = var.environment
     }
   }
 
@@ -78,6 +79,7 @@ resource "aws_eks_node_group" "al2023" {
   tags = {
     Name                                                   = local.al2023_name
     KubernetesCluster                                      = var.cluster_name
+    env                                                    = var.environment
     (format("kubernetes.io/cluster/%s", var.cluster_name)) = "owned"
   }
 }

--- a/firehose-audit.tf
+++ b/firehose-audit.tf
@@ -108,6 +108,7 @@ resource "aws_kinesis_firehose_delivery_stream" "eks_audit" {
 
   tags = {
     Environment = var.environment
+    env         = var.environment
   }
 }
 

--- a/node-groups-enclave-tracks.tf
+++ b/node-groups-enclave-tracks.tf
@@ -42,6 +42,7 @@ resource "aws_launch_template" "enclave_track" {
       Name              = "eks-node-enclaves-${each.key}-${var.cluster_name}"
       KubernetesCluster = var.cluster_name
       EnclaveTrack      = each.key
+      env               = var.environment
     }
   }
 

--- a/node-groups.tf
+++ b/node-groups.tf
@@ -33,6 +33,7 @@ resource "aws_launch_template" "this" {
     tags = {
       Name              = "eks-node-${var.cluster_name}"
       KubernetesCluster = var.cluster_name
+      env               = var.environment
     }
   }
 


### PR DESCRIPTION
Requestor/Issue: INFRA-6654
Tested (yes/no): yes
Description/Why: Adds AWS tag `env` alongside the existing environment tagging on EKS node host resources and the audit Firehose delivery stream so Datadog can read the expected tag during migration while the existing tag remains available.

Host coverage:
- regular ASG launch template instance tags
- managed AL2023 launch template instance tags
- managed AL2023 node group tags
- enclave-track launch template instance tags

Validation:
- `TFENV_TERRAFORM_VERSION=1.12.1 terraform fmt -check firehose-audit.tf node-groups.tf eks-node-group.tf node-groups-enclave-tracks.tf`
- `TFENV_TERRAFORM_VERSION=1.12.1 terraform validate` outside the sandbox after the sandboxed provider plugin startup failed