### PR TITLE
[codex] INFRA-6654 capitalize Env tag

### DIFF
--- a/eks-node-group.tf
+++ b/eks-node-group.tf
@@ -34,7 +34,7 @@ resource "aws_launch_template" "al2023" {
     tags = {
       Name              = local.al2023_name
       KubernetesCluster = var.cluster_name
-      env               = var.environment
+      Env               = var.environment
     }
   }
 
@@ -79,7 +79,7 @@ resource "aws_eks_node_group" "al2023" {
   tags = {
     Name                                                   = local.al2023_name
     KubernetesCluster                                      = var.cluster_name
-    env                                                    = var.environment
+    Env                                                    = var.environment
     (format("kubernetes.io/cluster/%s", var.cluster_name)) = "owned"
   }
 }

--- a/firehose-audit.tf
+++ b/firehose-audit.tf
@@ -108,7 +108,7 @@ resource "aws_kinesis_firehose_delivery_stream" "eks_audit" {
 
   tags = {
     Environment = var.environment
-    env         = var.environment
+    Env         = var.environment
   }
 }
 

--- a/node-groups-enclave-tracks.tf
+++ b/node-groups-enclave-tracks.tf
@@ -42,7 +42,7 @@ resource "aws_launch_template" "enclave_track" {
       Name              = "eks-node-enclaves-${each.key}-${var.cluster_name}"
       KubernetesCluster = var.cluster_name
       EnclaveTrack      = each.key
-      env               = var.environment
+      Env               = var.environment
     }
   }
 

--- a/node-groups.tf
+++ b/node-groups.tf
@@ -33,7 +33,7 @@ resource "aws_launch_template" "this" {
     tags = {
       Name              = "eks-node-${var.cluster_name}"
       KubernetesCluster = var.cluster_name
-      env               = var.environment
+      Env               = var.environment
     }
   }
 


### PR DESCRIPTION
Requestor/Issue: INFRA-6654
Tested (yes/no): yes
Description/Why: Follow-up to the already-merged INFRA-6654 tag migration. Renames the newly added AWS tag key from `env` to `Env` on EKS node host resources and the audit Firehose delivery stream to match the repository AWS tag naming convention while preserving the existing `Environment` tag.

Validation:
- `TFENV_TERRAFORM_VERSION=1.12.1 terraform fmt -check firehose-audit.tf node-groups.tf eks-node-group.tf node-groups-enclave-tracks.tf`
- `TFENV_TERRAFORM_VERSION=1.12.1 terraform validate`
