### PR TITLE
INFRA-6681: add node_ami_kubernetes_version to decouple node AMI from cluster_version

### DIFF
--- a/datasources.tf
+++ b/datasources.tf
@@ -13,8 +13,8 @@ locals {
   node_ami_k8s_version = coalesce(var.node_ami_kubernetes_version, var.cluster_version)
 
   al2023_standard_ami = {
-    amd64 = format("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", local.node_ami_k8s_version)
-    arm64 = format("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/arm64/standard/recommended/image_id", local.node_ami_k8s_version)
+    amd64 = format("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/%s/image_id", local.node_ami_k8s_version, var.node_ami_release_version)
+    arm64 = format("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/arm64/standard/%s/image_id", local.node_ami_k8s_version, var.node_ami_release_version)
   }
 }
 

--- a/datasources.tf
+++ b/datasources.tf
@@ -10,9 +10,11 @@ locals {
   effective_internal_cert_arn = var.internal_cert_arn != "" ? var.internal_cert_arn : (var.internal_nlb_acm_arn != "" ? var.internal_nlb_acm_arn : local.effective_external_cert_arn)
   effective_nlb_service_ports = length(var.internal_nlb_service_ports) > 0 ? var.internal_nlb_service_ports : var.traefik_nlb_service_ports
 
+  node_ami_k8s_version = coalesce(var.node_ami_kubernetes_version, var.cluster_version)
+
   al2023_standard_ami = {
-    amd64 = format("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", var.cluster_version)
-    arm64 = format("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/arm64/standard/recommended/image_id", var.cluster_version)
+    amd64 = format("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/x86_64/standard/recommended/image_id", local.node_ami_k8s_version)
+    arm64 = format("/aws/service/eks/optimized-ami/%s/amazon-linux-2023/arm64/standard/recommended/image_id", local.node_ami_k8s_version)
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,12 @@ variable "cluster_version" {
   default     = "1.35"
 }
 
+variable "node_ami_kubernetes_version" {
+  description = "Kubernetes version used to look up the AL2023 node AMI from SSM. Overrides cluster_version for AMI selection only - the EKS control plane still uses cluster_version. Defaults to null (use cluster_version). Set to a lower version to keep nodes on an older Kubernetes minor while the control plane is upgraded (within EKS skew policy, up to 3 minor versions behind)."
+  type        = string
+  default     = null
+}
+
 variable "vpc_config" {
   description = "VPC configuration from aws/vps module"
   type = object({

--- a/variables.tf
+++ b/variables.tf
@@ -37,7 +37,7 @@ variable "cluster_version" {
 }
 
 variable "node_ami_kubernetes_version" {
-  description = "Kubernetes version used to look up the AL2023 node AMI from SSM. Overrides cluster_version for AMI selection only - the EKS control plane still uses cluster_version. Defaults to null (use cluster_version). Set to a lower version to keep nodes on an older Kubernetes minor while the control plane is upgraded (within EKS skew policy, up to 3 minor versions behind)."
+  description = "Kubernetes version used to look up the AL2023 node AMI from SSM. Overrides cluster_version for AMI selection only; the EKS control plane still uses cluster_version. Defaults to null (use cluster_version)."
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,12 @@ variable "node_ami_kubernetes_version" {
   default     = null
 }
 
+variable "node_ami_release_version" {
+  description = "AL2023 EKS-optimized AMI release version used in the SSM lookup (e.g. '1.33.11-20260615'). Defaults to 'recommended', which is the AWS-managed pointer that moves as new patches are published, causing nodes to rotate on every patch release. Set to a specific release version to fully pin the node AMI - no rotation on AWS patch releases."
+  type        = string
+  default     = "recommended"
+}
+
 variable "vpc_config" {
   description = "VPC configuration from aws/vps module"
   type = object({


### PR DESCRIPTION
Issue:
INFRA-6681

Tested (yes/no):
no

Description/Why:
Adds two optional variables to fully pin the AL2023 node AMI independently of `cluster_version`:

- `node_ami_kubernetes_version` (default `null`) - overrides the Kubernetes minor in the SSM lookup.
- `node_ami_release_version` (default `"recommended"`) - overrides the AMI release alias in the SSM lookup. Setting a specific release (e.g. `"1.33.11-20260615"`) pins the exact AMI patch.

Today the launch_template's `image_id` comes from the SSM `recommended` alias keyed on `cluster_version`. That gives two implicit rotation triggers: bumping `cluster_version`, and AWS publishing a new patch (the `recommended` pointer moves with no code change). Both knobs are needed for consumers that must defer node rotation (ML data collection in progress, single capacity-reserved instances, etc.).

Defaults preserve current behavior - existing consumers are not affected.