### PR TITLE
INFRA-6690: Enable mTLS for external ALB default listener

### DIFF
--- a/kubernetes-gateway-api-manifests.tf
+++ b/kubernetes-gateway-api-manifests.tf
@@ -37,11 +37,19 @@ locals {
     targetGroupStickiness = null
   }
 
+  _ext_alb_mtls_config = (
+    var.gateway_api_external_enabled && !var.open_to_all && var.mtls_enabled
+    ) ? {
+    mode       = "verify"
+    trustStore = module.gateway_api_external_alb[local.gateway_api_external_alb_name].trust_store_arn
+  } : null
+
   _default_ext_alb_listener_configs = [{
-    protocolPort       = "HTTPS:443"
-    alpnPolicy         = "None"
-    sslPolicy          = local.gateway_api_ssl_policies[var.external_tls_listener_version]
-    defaultCertificate = local.effective_external_cert_arn
+    protocolPort         = "HTTPS:443"
+    alpnPolicy           = "None"
+    sslPolicy            = local.gateway_api_ssl_policies[var.external_tls_listener_version]
+    defaultCertificate   = local.effective_external_cert_arn
+    mutualAuthentication = local._ext_alb_mtls_config
   }]
 
   _default_ext_nlb_listener_configs = [{

--- a/kubernetes-gw-ext-alb.tf
+++ b/kubernetes-gw-ext-alb.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 module "gateway_api_external_alb" {
-  source   = "git::https://github.com/worldcoin/terraform-aws-alb.git?ref=v1.6.0"
+  source   = "git::https://github.com/worldcoin/terraform-aws-alb.git?ref=v1.6.1"
   for_each = var.gateway_api_external_enabled ? toset([local.gateway_api_external_alb_name]) : []
 
   name_suffix  = each.key

--- a/kubernetes-gw-int-alb.tf
+++ b/kubernetes-gw-int-alb.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 module "gateway_api_internal_alb" {
-  source   = "git::https://github.com/worldcoin/terraform-aws-alb.git?ref=v1.6.0"
+  source   = "git::https://github.com/worldcoin/terraform-aws-alb.git?ref=v1.6.1"
   for_each = var.gateway_api_internal_enabled ? toset([local.gateway_api_internal_alb_name]) : []
 
   name_suffix  = each.key

--- a/kubernetes-traefik-external.tf
+++ b/kubernetes-traefik-external.tf
@@ -93,7 +93,7 @@ resource "kubernetes_ingress_v1" "treafik_ingress" {
 }
 
 module "alb" {
-  source   = "git::https://github.com/worldcoin/terraform-aws-alb.git?ref=v1.6.0"
+  source   = "git::https://github.com/worldcoin/terraform-aws-alb.git?ref=v1.6.1"
   for_each = var.external_alb_enabled ? toset([local.external_alb_name]) : []
 
   # because of lenght limitation of LB name we need to remove prefix treafik from internal NLB

--- a/tests/kubernetes-gateway-api.tftest.hcl
+++ b/tests/kubernetes-gateway-api.tftest.hcl
@@ -377,6 +377,88 @@ run "gateway_api_lb_name_prefix_empty_string_fails_validation" {
 # =============================================================================
 # Test: SSL policy derived from TLS listener version
 # =============================================================================
+# =============================================================================
+# Test: mTLS enabled by default (mtls_enabled=true, open_to_all=false)
+# =============================================================================
+run "gateway_api_mtls_enabled_by_default" {
+  command = plan
+
+  variables {
+    kubernetes_provider_enabled  = true
+    gateway_api_crds_enabled     = true
+    gateway_api_external_enabled = true
+    gateway_api_lb_name_prefix   = "test"
+  }
+
+  assert {
+    condition     = local._ext_alb_mtls_config != null
+    error_message = "mTLS config should be set when mtls_enabled=true and open_to_all=false"
+  }
+
+  assert {
+    condition     = local._ext_alb_mtls_config.mode == "verify"
+    error_message = "mTLS mode should be 'verify'"
+  }
+
+  assert {
+    condition     = contains(keys(local.gateway_api_ext_alb_listener_configs[0]), "mutualAuthentication")
+    error_message = "Default ext ALB listener config should include mutualAuthentication"
+  }
+}
+
+# =============================================================================
+# Test: mTLS disabled when open_to_all=true
+# =============================================================================
+run "gateway_api_mtls_disabled_when_open_to_all" {
+  command = plan
+
+  variables {
+    kubernetes_provider_enabled  = true
+    gateway_api_crds_enabled     = true
+    gateway_api_external_enabled = true
+    gateway_api_lb_name_prefix   = "test"
+    open_to_all                  = true
+  }
+
+  assert {
+    condition     = local._ext_alb_mtls_config == null
+    error_message = "mTLS config should be null when open_to_all=true"
+  }
+
+  assert {
+    condition     = !contains(keys(local.gateway_api_ext_alb_listener_configs[0]), "mutualAuthentication")
+    error_message = "Default ext ALB listener config should not include mutualAuthentication when open_to_all=true"
+  }
+}
+
+# =============================================================================
+# Test: mTLS disabled when mtls_enabled=false
+# =============================================================================
+run "gateway_api_mtls_disabled_when_var_false" {
+  command = plan
+
+  variables {
+    kubernetes_provider_enabled  = true
+    gateway_api_crds_enabled     = true
+    gateway_api_external_enabled = true
+    gateway_api_lb_name_prefix   = "test"
+    mtls_enabled                 = false
+  }
+
+  assert {
+    condition     = local._ext_alb_mtls_config == null
+    error_message = "mTLS config should be null when mtls_enabled=false"
+  }
+
+  assert {
+    condition     = !contains(keys(local.gateway_api_ext_alb_listener_configs[0]), "mutualAuthentication")
+    error_message = "Default ext ALB listener config should not include mutualAuthentication when mtls_enabled=false"
+  }
+}
+
+# =============================================================================
+# Test: SSL policy derived from TLS listener version
+# =============================================================================
 run "gateway_api_ssl_policy_mapping" {
   command = plan
 

--- a/tests/kubernetes-gateway-api.tftest.hcl
+++ b/tests/kubernetes-gateway-api.tftest.hcl
@@ -375,9 +375,6 @@ run "gateway_api_lb_name_prefix_empty_string_fails_validation" {
 }
 
 # =============================================================================
-# Test: SSL policy derived from TLS listener version
-# =============================================================================
-# =============================================================================
 # Test: mTLS enabled by default (mtls_enabled=true, open_to_all=false)
 # =============================================================================
 run "gateway_api_mtls_enabled_by_default" {


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-6690/enable-mtls-for-external-alb-default-listener
Tested (yes/no): yes
- https://github.com/worldcoin/infrastructure/pull/43814
- https://tfe.worldcoin.dev/app/TFH/workspaces/internal-tools-dev-us-east-1/runs/run-supKxXKVu3CFusJf
<img width="1247" height="741" alt="image" src="https://github.com/user-attachments/assets/8b4bbc55-2935-4f76-ac90-5b6f1b5cdfe7" />

Description/Why: migration from Traefik to Gateway API silently disabled mTLS on external ALBs 🤦  the trust store was still created, but the `LoadBalancerConfiguration` listener config never included `mutualAuthentication` because the listener is no longer managed by the ALB module (`create_default_listener = false`)
