### PR TITLE
feat: add gateway_api_{ext,int}_alb_extra_certificates for SNI certs

### DIFF
--- a/kubernetes-gateway-api-manifests.tf
+++ b/kubernetes-gateway-api-manifests.tf
@@ -49,6 +49,7 @@ locals {
     alpnPolicy           = "None"
     sslPolicy            = local.gateway_api_ssl_policies[var.external_tls_listener_version]
     defaultCertificate   = local.effective_external_cert_arn
+    certificates         = length(var.gateway_api_ext_alb_extra_certificates) > 0 ? var.gateway_api_ext_alb_extra_certificates : null
     mutualAuthentication = local._ext_alb_mtls_config
   }]
 
@@ -64,6 +65,7 @@ locals {
     alpnPolicy         = "None"
     sslPolicy          = local.gateway_api_ssl_policies[var.internal_tls_listener_version]
     defaultCertificate = local.effective_internal_cert_arn
+    certificates       = length(var.gateway_api_int_alb_extra_certificates) > 0 ? var.gateway_api_int_alb_extra_certificates : null
   }]
 
   _default_int_nlb_listener_configs = [{
@@ -74,13 +76,14 @@ locals {
   }]
 
   # Resolve listener configs: use override if provided, otherwise per-LB defaults.
-  # merge() ensures all CRD attributes exist (required by kubernetes_manifest provider),
-  # then `if v != null` strips null keys so only caller-set fields appear in the manifest,
-  # preventing drift on clusters using defaults.
-  gateway_api_ext_alb_listener_configs = [for cfg in coalesce(var.gateway_api_ext_alb_listener_configs, local._default_ext_alb_listener_configs) : { for k, v in merge(local._listener_config_defaults, cfg) : k => v if v != null }]
-  gateway_api_ext_nlb_listener_configs = [for cfg in coalesce(var.gateway_api_ext_nlb_listener_configs, local._default_ext_nlb_listener_configs) : { for k, v in merge(local._listener_config_defaults, cfg) : k => v if v != null }]
-  gateway_api_int_alb_listener_configs = [for cfg in coalesce(var.gateway_api_int_alb_listener_configs, local._default_int_alb_listener_configs) : { for k, v in merge(local._listener_config_defaults, cfg) : k => v if v != null }]
-  gateway_api_int_nlb_listener_configs = [for cfg in coalesce(var.gateway_api_int_nlb_listener_configs, local._default_int_nlb_listener_configs) : { for k, v in merge(local._listener_config_defaults, cfg) : k => v if v != null }]
+  # Each element is pre-merged with _listener_config_defaults so both ternary branches
+  # share one object type (coalesce/ternary require it), which lets callers pass partial
+  # overrides. The final `if v != null` strips null keys so only set fields reach the
+  # manifest, preventing drift on clusters using defaults.
+  gateway_api_ext_alb_listener_configs = [for cfg in(var.gateway_api_ext_alb_listener_configs != null ? [for c in var.gateway_api_ext_alb_listener_configs : merge(local._listener_config_defaults, c)] : [for c in local._default_ext_alb_listener_configs : merge(local._listener_config_defaults, c)]) : { for k, v in cfg : k => v if v != null }]
+  gateway_api_ext_nlb_listener_configs = [for cfg in(var.gateway_api_ext_nlb_listener_configs != null ? [for c in var.gateway_api_ext_nlb_listener_configs : merge(local._listener_config_defaults, c)] : [for c in local._default_ext_nlb_listener_configs : merge(local._listener_config_defaults, c)]) : { for k, v in cfg : k => v if v != null }]
+  gateway_api_int_alb_listener_configs = [for cfg in(var.gateway_api_int_alb_listener_configs != null ? [for c in var.gateway_api_int_alb_listener_configs : merge(local._listener_config_defaults, c)] : [for c in local._default_int_alb_listener_configs : merge(local._listener_config_defaults, c)]) : { for k, v in cfg : k => v if v != null }]
+  gateway_api_int_nlb_listener_configs = [for cfg in(var.gateway_api_int_nlb_listener_configs != null ? [for c in var.gateway_api_int_nlb_listener_configs : merge(local._listener_config_defaults, c)] : [for c in local._default_int_nlb_listener_configs : merge(local._listener_config_defaults, c)]) : { for k, v in cfg : k => v if v != null }]
 }
 
 # CRDs: Gateway API (v1.5.1) + AWS LBC Gateway CRDs (v3.2.1)

--- a/tests/kubernetes-gateway-api.tftest.hcl
+++ b/tests/kubernetes-gateway-api.tftest.hcl
@@ -225,6 +225,142 @@ run "gateway_api_internal_only_no_cert_fails" {
 }
 
 # =============================================================================
+# Test: gateway_api_int_alb_extra_certificates defaults to empty (no certificates key)
+# =============================================================================
+run "gateway_api_int_alb_extra_certs_default_empty" {
+  command = plan
+
+  variables {
+    gateway_api_crds_enabled     = true
+    gateway_api_internal_enabled = true
+    external_alb_enabled         = false
+    internal_nlb_enabled         = false
+    internal_cert_arn            = "arn:aws:acm:us-east-1:123412341234:certificate/aabbcc11-1312-abcd-qwer-1a2s3d4f5g6h"
+  }
+
+  assert {
+    condition     = !contains(keys(local.gateway_api_int_alb_listener_configs[0]), "certificates")
+    error_message = "certificates key should be absent when gateway_api_int_alb_extra_certificates is empty"
+  }
+}
+
+# =============================================================================
+# Test: gateway_api_int_alb_extra_certificates appends SNI certs to the default listener
+# =============================================================================
+run "gateway_api_int_alb_extra_certs_appended" {
+  command = plan
+
+  variables {
+    gateway_api_crds_enabled     = true
+    gateway_api_internal_enabled = true
+    external_alb_enabled         = false
+    internal_nlb_enabled         = false
+    internal_cert_arn            = "arn:aws:acm:us-east-1:123412341234:certificate/aabbcc11-1312-abcd-qwer-1a2s3d4f5g6h"
+    gateway_api_int_alb_extra_certificates = [
+      "arn:aws:acm:us-east-1:123412341234:certificate/99887766-1312-abcd-qwer-1a2s3d4f5g6h"
+    ]
+  }
+
+  assert {
+    condition     = length(local.gateway_api_int_alb_listener_configs[0].certificates) == 1 && contains(local.gateway_api_int_alb_listener_configs[0].certificates, "arn:aws:acm:us-east-1:123412341234:certificate/99887766-1312-abcd-qwer-1a2s3d4f5g6h")
+    error_message = "extra certificates should appear as SNI certificates on the internal ALB listener"
+  }
+
+  assert {
+    condition     = local.gateway_api_int_alb_listener_configs[0].defaultCertificate == "arn:aws:acm:us-east-1:123412341234:certificate/aabbcc11-1312-abcd-qwer-1a2s3d4f5g6h"
+    error_message = "defaultCertificate should still resolve from the internal cert"
+  }
+}
+
+# =============================================================================
+# Test: full listener override ignores gateway_api_int_alb_extra_certificates
+# =============================================================================
+run "gateway_api_int_alb_extra_certs_ignored_on_override" {
+  command = plan
+
+  variables {
+    gateway_api_crds_enabled     = true
+    gateway_api_internal_enabled = true
+    external_alb_enabled         = false
+    internal_nlb_enabled         = false
+    internal_cert_arn            = "arn:aws:acm:us-east-1:123412341234:certificate/aabbcc11-1312-abcd-qwer-1a2s3d4f5g6h"
+    gateway_api_int_alb_extra_certificates = [
+      "arn:aws:acm:us-east-1:123412341234:certificate/99887766-1312-abcd-qwer-1a2s3d4f5g6h"
+    ]
+    gateway_api_int_alb_listener_configs = [{
+      protocolPort       = "HTTPS:443"
+      defaultCertificate = "arn:aws:acm:us-east-1:123412341234:certificate/aabbcc11-1312-abcd-qwer-1a2s3d4f5g6h"
+    }]
+  }
+
+  assert {
+    condition     = !contains(keys(local.gateway_api_int_alb_listener_configs[0]), "certificates")
+    error_message = "extra certificates must be ignored when a full listener override is provided"
+  }
+}
+
+# =============================================================================
+# Test: gateway_api_ext_alb_extra_certificates defaults to empty (no certificates key)
+# =============================================================================
+run "gateway_api_ext_alb_extra_certs_default_empty" {
+  command = plan
+
+  variables {
+    gateway_api_crds_enabled     = true
+    gateway_api_external_enabled = true
+  }
+
+  assert {
+    condition     = !contains(keys(local.gateway_api_ext_alb_listener_configs[0]), "certificates")
+    error_message = "certificates key should be absent when gateway_api_ext_alb_extra_certificates is empty"
+  }
+}
+
+# =============================================================================
+# Test: gateway_api_ext_alb_extra_certificates appends SNI certs to the default listener
+# =============================================================================
+run "gateway_api_ext_alb_extra_certs_appended" {
+  command = plan
+
+  variables {
+    gateway_api_crds_enabled     = true
+    gateway_api_external_enabled = true
+    gateway_api_ext_alb_extra_certificates = [
+      "arn:aws:acm:us-east-1:123412341234:certificate/99887766-1312-abcd-qwer-1a2s3d4f5g6h"
+    ]
+  }
+
+  assert {
+    condition     = length(local.gateway_api_ext_alb_listener_configs[0].certificates) == 1 && contains(local.gateway_api_ext_alb_listener_configs[0].certificates, "arn:aws:acm:us-east-1:123412341234:certificate/99887766-1312-abcd-qwer-1a2s3d4f5g6h")
+    error_message = "extra certificates should appear as SNI certificates on the external ALB listener"
+  }
+}
+
+# =============================================================================
+# Test: full external listener override ignores gateway_api_ext_alb_extra_certificates
+# =============================================================================
+run "gateway_api_ext_alb_extra_certs_ignored_on_override" {
+  command = plan
+
+  variables {
+    gateway_api_crds_enabled     = true
+    gateway_api_external_enabled = true
+    gateway_api_ext_alb_extra_certificates = [
+      "arn:aws:acm:us-east-1:123412341234:certificate/99887766-1312-abcd-qwer-1a2s3d4f5g6h"
+    ]
+    gateway_api_ext_alb_listener_configs = [{
+      protocolPort       = "HTTPS:443"
+      defaultCertificate = "arn:aws:acm:us-east-1:123412341234:certificate/aabbcc11-1312-abcd-qwer-1a2s3d4f5g6h"
+    }]
+  }
+
+  assert {
+    condition     = !contains(keys(local.gateway_api_ext_alb_listener_configs[0]), "certificates")
+    error_message = "extra certificates must be ignored when a full listener override is provided"
+  }
+}
+
+# =============================================================================
 # Test: K8s manifests disabled by default (gateway_api_*_enabled = false)
 # =============================================================================
 run "gateway_api_k8s_manifests_disabled_by_default" {

--- a/variables.tf
+++ b/variables.tf
@@ -1176,6 +1176,12 @@ variable "gateway_api_ext_alb_listener_configs" {
   default     = null
 }
 
+variable "gateway_api_ext_alb_extra_certificates" {
+  description = "Additional ACM certificate ARNs to attach as SNI certificates on the external ALB HTTPS listener, alongside the default certificate. Lets callers add SNI certs without restating listener defaults. Ignored when gateway_api_ext_alb_listener_configs is set (full override wins)."
+  type        = list(string)
+  default     = []
+}
+
 variable "gateway_api_ext_nlb_listener_configs" {
   description = "Override LoadBalancerConfiguration listenerConfigurations for the external NLB. When null, defaults to TLS:443 with external cert and SSL policy."
   type        = any
@@ -1186,6 +1192,12 @@ variable "gateway_api_int_alb_listener_configs" {
   description = "Override LoadBalancerConfiguration listenerConfigurations for the internal ALB. When null, defaults to HTTPS:443 with internal cert and SSL policy."
   type        = any
   default     = null
+}
+
+variable "gateway_api_int_alb_extra_certificates" {
+  description = "Additional ACM certificate ARNs to attach as SNI certificates on the internal ALB HTTPS listener, alongside the default certificate. Lets callers add SNI certs without restating listener defaults. Ignored when gateway_api_int_alb_listener_configs is set (full override wins)."
+  type        = list(string)
+  default     = []
 }
 
 variable "gateway_api_int_nlb_listener_configs" {

--- a/variables.tf
+++ b/variables.tf
@@ -1177,9 +1177,10 @@ variable "gateway_api_ext_alb_listener_configs" {
 }
 
 variable "gateway_api_ext_alb_extra_certificates" {
-  description = "Additional ACM certificate ARNs to attach as SNI certificates on the external ALB HTTPS listener, alongside the default certificate. Lets callers add SNI certs without restating listener defaults. Ignored when gateway_api_ext_alb_listener_configs is set (full override wins)."
+  description = "Additional ACM certificate ARNs to attach as SNI certificates on the external ALB HTTPS listener, alongside the default certificate. Lets callers add SNI certs without restating listener defaults. Ignored when gateway_api_ext_alb_listener_configs is set (that override wins)."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "gateway_api_ext_nlb_listener_configs" {
@@ -1195,9 +1196,10 @@ variable "gateway_api_int_alb_listener_configs" {
 }
 
 variable "gateway_api_int_alb_extra_certificates" {
-  description = "Additional ACM certificate ARNs to attach as SNI certificates on the internal ALB HTTPS listener, alongside the default certificate. Lets callers add SNI certs without restating listener defaults. Ignored when gateway_api_int_alb_listener_configs is set (full override wins)."
+  description = "Additional ACM certificate ARNs to attach as SNI certificates on the internal ALB HTTPS listener, alongside the default certificate. Lets callers add SNI certs without restating listener defaults. Ignored when gateway_api_int_alb_listener_configs is set (that override wins)."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "gateway_api_int_nlb_listener_configs" {


### PR DESCRIPTION
Requestor/Issue: INFRA-6395

Tested (yes/no): yes (`terraform fmt`, `terraform validate`, and `terraform test -filter=tests/kubernetes-gateway-api.tftest.hcl` in the module root — 26 passed, 0 failed)

Description/Why:
Callers that need a second SNI certificate on a Gateway API ALB currently have to override the whole `gateway_api_{ext,int}_alb_listener_configs`, restating `alpnPolicy`, `sslPolicy`, and `defaultCertificate`. That pins the module's internal defaults at call sites and drifts silently if the module later changes them (flagged in Copilot review of infrastructure#44459, the ml-prod internal-ACM change).

This adds dedicated inputs so callers can append SNI certs without restating defaults:
- `gateway_api_ext_alb_extra_certificates` (list(string), default `[]`)
- `gateway_api_int_alb_extra_certificates` (list(string), default `[]`)

Both append to the `certificates` (SNI) list on the respective HTTPS ALB listener while `defaultCertificate`, `sslPolicy`, and `alpnPolicy` keep tracking module defaults. When empty (default), no `certificates` key is emitted, so existing clusters are unaffected. A full `*_listener_configs` override still wins and ignores these inputs.

Also hardened listener-config resolution: replaced `coalesce()` with a null-check that pre-merges `_listener_config_defaults` into both branches, so partial overrides no longer fail on object type-unification.

Tests added: default-empty (no `certificates` key), extra-certs-appended, and override-wins for both external and internal ALB.

AI usage/prompt(s) (if applicable):
GitHub Copilot (Claude Opus 4.8) — prompted to add a dedicated "additional SNI certificates" input to avoid restating listener defaults (per Copilot's own review comment on infrastructure#44459), then "do the same for external ALB". Code, tests, and this description were AI-drafted and human-reviewed.
