### PR TITLE
chore(dependabot): group version updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "[github-actions] "
+    groups:
+      "github-actions":
+        patterns:
+          - '*'


### PR DESCRIPTION
Adds a single wildcard group per configured ecosystem so Dependabot batches version updates into one PR per ecosystem instead of one-per-dependency.

Standardizes the pattern established in tfhcli#299 across infra-owned repos. Only existing ecosystem entries are grouped; no new entries added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)