### PR TITLE
fix(karpenter): make spot interruption EventBridge rules per-cluster (INFRA-6779)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ Release is created as draft, so you have to edit it manually and change it to fi
 
 ## Breaking changes
 
+### Karpenter spot interruption EventBridge rules are now per-cluster
+
+The spot interruption EventBridge rules (`aws_cloudwatch_event_rule.spot_aws_health`
+and `aws_cloudwatch_event_rule.spot_aws_ec2`) are now named per-cluster:
+`spot-aws-health-${cluster_name}` and `spot-aws-ec2-${cluster_name}`. Previously
+they used the fixed regional names `spot-aws-health` / `spot-aws-ec2`, which two
+clusters in the same AWS account and region shared and fought over from separate
+Terraform states.
+
+**Migration for existing clusters:** the Terraform resource addresses are unchanged
+(only the `name` attribute changed), so no state surgery is required — a normal
+`terraform apply` replaces each rule and its target in place. EventBridge rule
+replacement is a destroy-then-create; expect a brief (few-second) window during the
+apply where spot interruption events for that cluster are not delivered to its SQS
+queue. Run the apply during a maintenance window if that matters for the cluster.
+
+After migration, each cluster owns its own rules, so creating or destroying one
+cluster no longer affects spot interruption handling for another cluster in the same
+account/region. The previous manual `terraform state rm` workaround during cluster
+removal is no longer needed and has been removed from the removal steps below.
+
 ### Version 10.0.0 - Kubernetes Resource Type Migration
 
 Version 10.0.0 introduces a breaking change due to upgrading deprecated `kubernetes_*` resources to their `kubernetes_*_v1` counterparts. This affects the following resources:
@@ -595,8 +616,6 @@ To remove the cluster you have to:
 
    terraform state rm ...
    ```
-
-1. if there are other clusters in the same region, remove `aws_cloudwatch_event_rule.spot_aws_health aws_cloudwatch_event_rule.spot_aws_ec2` from the state manually.
 
 1. Remove module invocation to finally delete cluster itself.
 

--- a/sqs-karpenter.tf
+++ b/sqs-karpenter.tf
@@ -37,7 +37,7 @@ resource "aws_sqs_queue_policy" "spot_notifications_sqs" {
 
 # Rules
 resource "aws_cloudwatch_event_rule" "spot_aws_health" {
-  name        = "spot-aws-health"
+  name        = "spot-aws-health-${var.cluster_name}"
   description = "Capture each scheduled change event from AWS Health"
 
   event_pattern = jsonencode({
@@ -55,7 +55,7 @@ resource "aws_cloudwatch_event_target" "spot_aws_health" {
 }
 
 resource "aws_cloudwatch_event_rule" "spot_aws_ec2" {
-  name        = "spot-aws-ec2"
+  name        = "spot-aws-ec2-${var.cluster_name}"
   description = "Capture aws.ec2 spot instance events"
 
   event_pattern = jsonencode({

--- a/tests/sqs-karpenter.tftest.hcl
+++ b/tests/sqs-karpenter.tftest.hcl
@@ -1,0 +1,40 @@
+# Mock (offline) provider
+mock_provider "aws" {
+  source = "./tests/mocks/aws" # Path to the directory containing the mock files
+}
+
+mock_provider "datadog" {}
+
+mock_provider "cloudflare" {}
+
+mock_provider "kubernetes" {
+  source = "./tests/mocks/kubernetes" # Path to the directory containing the mock files
+}
+
+variables {
+  # Disable kubernetes provider to avoid import block issues with mock provider
+  kubernetes_provider_enabled = false
+}
+
+# Asserts the Karpenter spot interruption EventBridge rules are cluster-scoped, so
+# two clusters in the same AWS account/region never share or fight over the same
+# regional rule names (INFRA-6779).
+run "spot_interruption_rules_are_cluster_scoped" {
+  command = plan
+
+  assert {
+    condition     = aws_cloudwatch_event_rule.spot_aws_ec2.name == "spot-aws-ec2-${var.cluster_name}"
+    error_message = "spot_aws_ec2 EventBridge rule name must be scoped to the cluster name"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_event_rule.spot_aws_health.name == "spot-aws-health-${var.cluster_name}"
+    error_message = "spot_aws_health EventBridge rule name must be scoped to the cluster name"
+  }
+
+  # Each rule delivers to this cluster's own SQS queue, which is already per-cluster.
+  assert {
+    condition     = aws_sqs_queue.this.name == "spot-notifications-${var.cluster_name}"
+    error_message = "spot notifications SQS queue name must be scoped to the cluster name"
+  }
+}


### PR DESCRIPTION
Requestor/Issue: INFRA-6779

Tested (yes/no): no — not applied to live infra. `terraform fmt` passes locally; the full `terraform test` harness could not run locally due to a pre-existing `cloudflare` provider-source quirk in the test dir (reproduces on `main`, unrelated to this change), so the new `tests/sqs-karpenter.tftest.hcl` is exercised by CI's fresh-init `terraform test`.

Description/Why:
The Karpenter spot interruption EventBridge rules used fixed regional names (`spot-aws-health` / `spot-aws-ec2`). EventBridge rules are regional, account-level resources, so two EKS clusters in the same AWS account and region shared them across separate Terraform states. Apply in one cluster could adopt/collide with the shared rules, and destroying one cluster could delete rules still needed by another — breaking Karpenter spot interruption handling. The README worked around this by asking operators to manually `terraform state rm` the rules during cluster teardown, which is easy to miss.

This scopes the rule names to the cluster (`spot-aws-health-${cluster_name}`, `spot-aws-ec2-${cluster_name}`) so each cluster owns its own rules and targets. The SQS queue and Karpenter IAM were already per-cluster, and Karpenter binds to the queue (`settings.interruptionQueue`), not the rule names — so nothing external references these rule names and the rename is fully self-contained.

Changes:
- `sqs-karpenter.tf`: rule names scoped to `${var.cluster_name}`.
- `README.md`: removed the manual `terraform state rm` workaround from the cluster removal steps; documented the rename + migration path under Breaking changes.
- `tests/sqs-karpenter.tftest.hcl`: asserts the EventBridge rule names and the SQS queue are cluster-scoped.

Migration: resource addresses are unchanged (only the `name` attribute changed), so existing clusters migrate via a normal `terraform apply` — no state surgery. Rule replacement is destroy-then-create, so expect a brief (few-second) window during apply where spot interruption events are not delivered; run during a maintenance window if that matters.

Acceptance criteria:
- Two clusters in the same account/region no longer share/collide on spot interruption rules.
- Destroying one cluster no longer removes another cluster's rules.
- README `terraform state rm` workaround removed / replaced with accurate guidance.
- Migration path documented for existing clusters.
- Terraform test added asserting names are cluster-scoped.

AI usage/prompt(s) (if applicable):
AI-assisted (Claude Code / Claude Opus). Prompts (translated from Polish): "look at task INFRA-6779, what needs to be done there?" → "do it" (investigate the repo and implement one of the ticket's proposed options) → "push the branch and open a PR".
