### PR TITLE
INFRA-7029: allow Karpenter to create the EC2 Spot service-linked role

### DIFF
--- a/iam-karpenter.tf
+++ b/iam-karpenter.tf
@@ -177,6 +177,17 @@ data "aws_iam_policy_document" "karpenter" {
     ]
     resources = [aws_sqs_queue.this.arn]
   }
+  statement {
+    sid       = "AllowScopedEC2SpotServiceLinkedRoleCreation"
+    effect    = "Allow"
+    actions   = ["iam:CreateServiceLinkedRole"]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.account.id}:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:AWSServiceName"
+      values   = ["spot.amazonaws.com"]
+    }
+  }
 }
 
 resource "aws_iam_role" "karpenter" {


### PR DESCRIPTION
Requestor/Issue: INFRA-7029
Tested (yes/no): yes (`terraform fmt -check`, `terraform init -backend=false`, `terraform validate` all pass in the repo root)
Description/Why: One of our production clusters hit `AuthFailure.ServiceLinkedRoleCreationNotPermitted` when Karpenter tried to fall back to Spot during an on-demand capacity crunch. Root cause: the account had never launched a Spot instance before, so `AWSServiceRoleForEC2Spot` didn't exist yet, and the Karpenter controller role had no permission to create it inline the way `CreateFleet` expects. Rather than a one-off `aws iam create-service-linked-role` CLI call, or a Terraform-managed account-wide singleton resource (which would fail with `InvalidInput: ...has been taken` on accounts that already have the role), this grants the permission directly to each cluster's own Karpenter controller role, scoped to only the EC2 Spot service-linked role. It's a pure permission widening — a no-op in accounts that already have the role, self-healing in accounts that don't.

AI usage/prompt(s) (if applicable): Claude Code 