### PR TITLE
INFRA-6980: fix gateway_api_*_sg_rules override variables (additive, properly typed)

### DIFF
--- a/kubernetes-gw-ext-alb.tf
+++ b/kubernetes-gw-ext-alb.tf
@@ -1,11 +1,10 @@
 locals {
   gateway_api_external_alb_name = "gw-ext-alb"
 
-  # Default is [] — the ALB module manages frontend SG ingress internally
-  # using open_to_all (Cloudflare IPs or 0.0.0.0/0). backend_ingress_rules
-  # only adds extra rules to the backend SG which has no ingress by default.
-  # var.gateway_api_external_alb_sg_rules defaults to [] too, so this is a no-op concat when unset.
-  gateway_api_external_alb_sg_rules = concat([], var.gateway_api_external_alb_sg_rules)
+  # The ALB module manages frontend SG ingress internally using open_to_all
+  # (Cloudflare IPs or 0.0.0.0/0). backend_ingress_rules only adds extra rules
+  # to the backend SG, which has no default rules of its own to append to.
+  gateway_api_external_alb_sg_rules = var.gateway_api_external_alb_sg_rules
 }
 
 module "gateway_api_external_alb" {

--- a/kubernetes-gw-ext-alb.tf
+++ b/kubernetes-gw-ext-alb.tf
@@ -4,7 +4,8 @@ locals {
   # Default is [] — the ALB module manages frontend SG ingress internally
   # using open_to_all (Cloudflare IPs or 0.0.0.0/0). backend_ingress_rules
   # only adds extra rules to the backend SG which has no ingress by default.
-  gateway_api_external_alb_sg_rules = var.gateway_api_external_alb_sg_rules != null ? var.gateway_api_external_alb_sg_rules : []
+  # var.gateway_api_external_alb_sg_rules defaults to [] too, so this is a no-op concat when unset.
+  gateway_api_external_alb_sg_rules = concat([], var.gateway_api_external_alb_sg_rules)
 }
 
 module "gateway_api_external_alb" {

--- a/kubernetes-gw-ext-nlb.tf
+++ b/kubernetes-gw-ext-nlb.tf
@@ -1,28 +1,46 @@
 locals {
   gateway_api_external_nlb_name = "gw-ext-nlb"
 
+  # Every element shares the same key set (nulls for the unused ones) so this is a uniform
+  # list(object(...)) type, matching var.gateway_api_external_nlb_sg_rules's declared type —
+  # concat() below would otherwise hit "Inconsistent conditional result types" the moment an
+  # override doesn't structurally clone this default (see INFRA-6980).
   gateway_api_external_nlb_default_sg_rules = [
     {
-      description = "allow http from Cloudflare"
-      port        = 80
-      cidr_blocks = data.cloudflare_ip_ranges.cloudflare.ipv4_cidrs
+      description      = "allow http from Cloudflare"
+      protocol         = "tcp"
+      port             = 80
+      cidr_blocks      = data.cloudflare_ip_ranges.cloudflare.ipv4_cidrs
+      ipv6_cidr_blocks = null
+      security_groups  = null
     },
     {
       description      = "allow http from Cloudflare (IPv6)"
+      protocol         = "tcp"
       port             = 80
+      cidr_blocks      = null
       ipv6_cidr_blocks = data.cloudflare_ip_ranges.cloudflare.ipv6_cidrs
+      security_groups  = null
     },
     {
-      description = "allow https from Cloudflare"
-      port        = 443
-      cidr_blocks = data.cloudflare_ip_ranges.cloudflare.ipv4_cidrs
+      description      = "allow https from Cloudflare"
+      protocol         = "tcp"
+      port             = 443
+      cidr_blocks      = data.cloudflare_ip_ranges.cloudflare.ipv4_cidrs
+      ipv6_cidr_blocks = null
+      security_groups  = null
     },
     {
       description      = "allow https from Cloudflare (IPv6)"
+      protocol         = "tcp"
       port             = 443
+      cidr_blocks      = null
       ipv6_cidr_blocks = data.cloudflare_ip_ranges.cloudflare.ipv6_cidrs
+      security_groups  = null
     },
   ]
+
+  gateway_api_external_nlb_sg_rules = concat(local.gateway_api_external_nlb_default_sg_rules, var.gateway_api_external_nlb_sg_rules)
 }
 
 module "gateway_api_external_nlb" {
@@ -47,7 +65,7 @@ module "gateway_api_external_nlb" {
   vpc_id         = var.vpc_config.vpc_id
   public_subnets = var.vpc_config.public_subnets
 
-  ingress_sg_rules = var.gateway_api_external_nlb_sg_rules != null ? var.gateway_api_external_nlb_sg_rules : local.gateway_api_external_nlb_default_sg_rules
+  ingress_sg_rules = local.gateway_api_external_nlb_sg_rules
 
   enable_deletion_protection       = var.enable_deletion_protection
   enable_cross_zone_load_balancing = var.nlb_az_affinity.gateway_api_external.enable_cross_zone_load_balancing

--- a/kubernetes-gw-int-alb.tf
+++ b/kubernetes-gw-int-alb.tf
@@ -1,22 +1,34 @@
 locals {
   gateway_api_internal_alb_name = "gw-int-alb"
 
-  gateway_api_internal_alb_sg_rules = var.gateway_api_internal_alb_sg_rules != null ? var.gateway_api_internal_alb_sg_rules : concat(
+  # NOTE: terraform-aws-alb's backend_ingress_rules has no ipv6_cidr_blocks attribute (checked
+  # v1.6.1, the version pinned below) — the IPv6 rule below has never actually reached the ALB
+  # module with a functioning ipv6 key. Preserved as-is (pre-existing, out of scope for
+  # INFRA-6980); only normalized here so this local's own two branches type-check.
+  gateway_api_internal_alb_default_sg_rules = concat(
     [
       {
-        description = "Allow HTTPS from all internal networks"
-        port        = 443
-        cidr_blocks = ["10.0.0.0/8"]
+        description      = "Allow HTTPS from all internal networks"
+        protocol         = "tcp"
+        port             = 443
+        cidr_blocks      = ["10.0.0.0/8"]
+        ipv6_cidr_blocks = null
+        security_groups  = null
       },
     ],
     data.aws_vpc.cluster_vpc.ipv6_cidr_block != "" ? [
       {
         description      = "Allow HTTPS from VPC (IPv6)"
+        protocol         = "tcp"
         port             = 443
+        cidr_blocks      = null
         ipv6_cidr_blocks = [data.aws_vpc.cluster_vpc.ipv6_cidr_block]
+        security_groups  = null
       },
     ] : []
   )
+
+  gateway_api_internal_alb_sg_rules = concat(local.gateway_api_internal_alb_default_sg_rules, var.gateway_api_internal_alb_sg_rules)
 }
 
 module "gateway_api_internal_alb" {

--- a/kubernetes-gw-int-nlb.tf
+++ b/kubernetes-gw-int-nlb.tf
@@ -1,32 +1,50 @@
 locals {
   gateway_api_internal_nlb_name = "gw-int-nlb"
 
-  gateway_api_internal_nlb_sg_rules = var.gateway_api_internal_nlb_sg_rules != null ? var.gateway_api_internal_nlb_sg_rules : concat(
+  # Every element shares the same key set (nulls for the unused ones) so this is a uniform
+  # list(object(...)) type, matching var.gateway_api_internal_nlb_sg_rules's declared type —
+  # concat() below would otherwise hit "Inconsistent conditional result types" the moment an
+  # override doesn't structurally clone this default (see INFRA-6980).
+  gateway_api_internal_nlb_default_sg_rules = concat(
     [
       {
-        description = "Allow HTTP from all internal networks"
-        port        = 80
-        cidr_blocks = ["10.0.0.0/8"]
+        description      = "Allow HTTP from all internal networks"
+        protocol         = "tcp"
+        port             = 80
+        cidr_blocks      = ["10.0.0.0/8"]
+        ipv6_cidr_blocks = null
+        security_groups  = null
       },
       {
-        description = "Allow HTTPS from all internal networks"
-        port        = 443
-        cidr_blocks = ["10.0.0.0/8"]
+        description      = "Allow HTTPS from all internal networks"
+        protocol         = "tcp"
+        port             = 443
+        cidr_blocks      = ["10.0.0.0/8"]
+        ipv6_cidr_blocks = null
+        security_groups  = null
       },
     ],
     data.aws_vpc.cluster_vpc.ipv6_cidr_block != "" ? [
       {
         description      = "Allow HTTP from VPC (IPv6)"
+        protocol         = "tcp"
         port             = 80
+        cidr_blocks      = null
         ipv6_cidr_blocks = [data.aws_vpc.cluster_vpc.ipv6_cidr_block]
+        security_groups  = null
       },
       {
         description      = "Allow HTTPS from VPC (IPv6)"
+        protocol         = "tcp"
         port             = 443
+        cidr_blocks      = null
         ipv6_cidr_blocks = [data.aws_vpc.cluster_vpc.ipv6_cidr_block]
+        security_groups  = null
       },
     ] : []
   )
+
+  gateway_api_internal_nlb_sg_rules = concat(local.gateway_api_internal_nlb_default_sg_rules, var.gateway_api_internal_nlb_sg_rules)
 }
 
 module "gateway_api_internal_nlb" {

--- a/tests/kubernetes-gateway-api.tftest.hcl
+++ b/tests/kubernetes-gateway-api.tftest.hcl
@@ -689,3 +689,25 @@ run "gateway_api_sg_rules_default_unchanged_when_unset" {
     error_message = "With no override, only the 4 Cloudflare defaults should be present"
   }
 }
+
+# =============================================================================
+# Test: explicit null override behaves the same as unset (nullable = false)
+#
+# Per Copilot review feedback on #149 - without nullable = false, a caller
+# passing null explicitly (rather than omitting the argument) would bypass the
+# default and break both the validation's `for` expression and concat().
+# =============================================================================
+run "gateway_api_sg_rules_explicit_null_same_as_unset" {
+  command = plan
+
+  variables {
+    gateway_api_crds_enabled          = true
+    gateway_api_external_enabled      = true
+    gateway_api_external_nlb_sg_rules = null
+  }
+
+  assert {
+    condition     = length(local.gateway_api_external_nlb_sg_rules) == 4
+    error_message = "Explicit null override should be normalized to [] and behave like unset"
+  }
+}

--- a/tests/kubernetes-gateway-api.tftest.hcl
+++ b/tests/kubernetes-gateway-api.tftest.hcl
@@ -605,3 +605,87 @@ run "gateway_api_ssl_policy_mapping" {
     error_message = "TLS 1.2 should map to ELBSecurityPolicy-TLS-1-2-2017-01"
   }
 }
+
+# =============================================================================
+# Test: SG rule overrides are additive, not full replacement (INFRA-6980)
+#
+# Before this fix, providing any *_sg_rules override whose shape didn't exactly
+# clone the module's own default caused "Inconsistent conditional result types"
+# at plan time (var.X != null ? var.X : local.default, with differing tuple
+# lengths/shapes). These tests both prove a real plan succeeds with a
+# minimal, differently-shaped override, and that the defaults are preserved
+# alongside it (additive semantics) rather than replaced.
+# =============================================================================
+run "gateway_api_external_nlb_sg_rules_additive" {
+  command = plan
+
+  variables {
+    gateway_api_crds_enabled     = true
+    gateway_api_external_enabled = true
+    gateway_api_external_nlb_sg_rules = [
+      {
+        description = "allow tx-proxy direct access (Alchemy + testing)"
+        port        = 443
+        cidr_blocks = ["107.22.167.250/32", "44.223.208.168/32"]
+      }
+    ]
+  }
+
+  assert {
+    condition     = length(local.gateway_api_external_nlb_sg_rules) == 5
+    error_message = "Override should be appended to the 4 Cloudflare defaults, not replace them"
+  }
+
+  assert {
+    condition     = contains([for r in local.gateway_api_external_nlb_sg_rules : r.description], "allow http from Cloudflare")
+    error_message = "Cloudflare default rules must still be present after an override is supplied"
+  }
+
+  assert {
+    condition     = contains([for r in local.gateway_api_external_nlb_sg_rules : r.description], "allow tx-proxy direct access (Alchemy + testing)")
+    error_message = "Override rule must be present"
+  }
+}
+
+run "gateway_api_internal_alb_sg_rules_additive" {
+  command = plan
+
+  variables {
+    gateway_api_crds_enabled     = true
+    gateway_api_internal_enabled = true
+    external_alb_enabled         = false
+    internal_nlb_enabled         = false
+    internal_cert_arn            = "arn:aws:acm:us-east-1:123412341234:certificate/aabbcc11-1312-abcd-qwer-1a2s3d4f5g6h"
+    gateway_api_internal_alb_sg_rules = [
+      {
+        description     = "allow from peered VPC"
+        port            = 8443
+        security_groups = ["sg-0123456789abcdef0"]
+      }
+    ]
+  }
+
+  assert {
+    condition     = length(local.gateway_api_internal_alb_sg_rules) == 2
+    error_message = "Override should be appended to the 1 default internal-network rule, not replace it"
+  }
+
+  assert {
+    condition     = contains([for r in local.gateway_api_internal_alb_sg_rules : r.description], "Allow HTTPS from all internal networks")
+    error_message = "Default internal-network rule must still be present after an override is supplied"
+  }
+}
+
+run "gateway_api_sg_rules_default_unchanged_when_unset" {
+  command = plan
+
+  variables {
+    gateway_api_crds_enabled     = true
+    gateway_api_external_enabled = true
+  }
+
+  assert {
+    condition     = length(local.gateway_api_external_nlb_sg_rules) == 4
+    error_message = "With no override, only the 4 Cloudflare defaults should be present"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -983,58 +983,84 @@ variable "gateway_api_internal_enabled" {
 }
 
 variable "gateway_api_external_alb_sg_rules" {
-  description = "Override LB security group ingress rules for the external Gateway API ALB. When null, the ALB module defaults apply (Cloudflare IPs or open_to_all)."
-  type        = any
-  default     = null
+  description = "Additional LB security group ingress rules for the external Gateway API ALB, appended to the module's own defaults (Cloudflare IPs or open_to_all) — this does not replace them."
+  type = list(object({
+    description     = optional(string, "")
+    protocol        = optional(string, "tcp")
+    port            = number
+    cidr_blocks     = optional(list(string))
+    security_groups = optional(list(string))
+  }))
+  default = []
 
   validation {
-    condition = var.gateway_api_external_alb_sg_rules == null || alltrue([
-      for r in coalesce(var.gateway_api_external_alb_sg_rules, []) :
-      can(r.port) && (can(r.cidr_blocks) || can(r.security_groups))
+    condition = alltrue([
+      for r in var.gateway_api_external_alb_sg_rules :
+      r.cidr_blocks != null || r.security_groups != null
     ])
-    error_message = "Each rule must have a 'port' and at least one of 'cidr_blocks' or 'security_groups'."
+    error_message = "Each rule must specify at least one of 'cidr_blocks' or 'security_groups'."
   }
 }
 
 variable "gateway_api_internal_alb_sg_rules" {
-  description = "Override LB security group ingress rules for the internal Gateway API ALB. When null, allows HTTPS from all internal networks (10.0.0.0/8)."
-  type        = any
-  default     = null
+  description = "Additional LB security group ingress rules for the internal Gateway API ALB, appended to the module's own defaults (HTTPS from all internal networks) — this does not replace them."
+  type = list(object({
+    description     = optional(string, "")
+    protocol        = optional(string, "tcp")
+    port            = number
+    cidr_blocks     = optional(list(string))
+    security_groups = optional(list(string))
+  }))
+  default = []
 
   validation {
-    condition = var.gateway_api_internal_alb_sg_rules == null || alltrue([
-      for r in coalesce(var.gateway_api_internal_alb_sg_rules, []) :
-      can(r.port) && (can(r.cidr_blocks) || can(r.security_groups))
+    condition = alltrue([
+      for r in var.gateway_api_internal_alb_sg_rules :
+      r.cidr_blocks != null || r.security_groups != null
     ])
-    error_message = "Each rule must have a 'port' and at least one of 'cidr_blocks' or 'security_groups'."
+    error_message = "Each rule must specify at least one of 'cidr_blocks' or 'security_groups'."
   }
 }
 
 variable "gateway_api_external_nlb_sg_rules" {
-  description = "Override LB security group ingress rules for the external Gateway API NLB. When null, allows ports 80 and 443 from Cloudflare IPs."
-  type        = any
-  default     = null
+  description = "Additional LB security group ingress rules for the external Gateway API NLB, appended to the module's own defaults (ports 80/443 from Cloudflare IPs) — this does not replace them."
+  type = list(object({
+    description      = optional(string, "")
+    protocol         = optional(string, "tcp")
+    port             = number
+    cidr_blocks      = optional(list(string))
+    ipv6_cidr_blocks = optional(list(string))
+    security_groups  = optional(list(string))
+  }))
+  default = []
 
   validation {
-    condition = var.gateway_api_external_nlb_sg_rules == null || alltrue([
-      for r in coalesce(var.gateway_api_external_nlb_sg_rules, []) :
-      can(r.port) && (can(r.cidr_blocks) || can(r.ipv6_cidr_blocks) || can(r.security_groups))
+    condition = alltrue([
+      for r in var.gateway_api_external_nlb_sg_rules :
+      r.cidr_blocks != null || r.ipv6_cidr_blocks != null || r.security_groups != null
     ])
-    error_message = "Each rule must have a 'port' and at least one of 'cidr_blocks', 'ipv6_cidr_blocks', or 'security_groups'."
+    error_message = "Each rule must specify at least one of 'cidr_blocks', 'ipv6_cidr_blocks', or 'security_groups'."
   }
 }
 
 variable "gateway_api_internal_nlb_sg_rules" {
-  description = "Override LB security group ingress rules for the internal Gateway API NLB. When null, allows ports 80 and 443 from all internal networks (10.0.0.0/8)."
-  type        = any
-  default     = null
+  description = "Additional LB security group ingress rules for the internal Gateway API NLB, appended to the module's own defaults (ports 80/443 from all internal networks) — this does not replace them."
+  type = list(object({
+    description      = optional(string, "")
+    protocol         = optional(string, "tcp")
+    port             = number
+    cidr_blocks      = optional(list(string))
+    ipv6_cidr_blocks = optional(list(string))
+    security_groups  = optional(list(string))
+  }))
+  default = []
 
   validation {
-    condition = var.gateway_api_internal_nlb_sg_rules == null || alltrue([
-      for r in coalesce(var.gateway_api_internal_nlb_sg_rules, []) :
-      can(r.port) && (can(r.cidr_blocks) || can(r.ipv6_cidr_blocks) || can(r.security_groups))
+    condition = alltrue([
+      for r in var.gateway_api_internal_nlb_sg_rules :
+      r.cidr_blocks != null || r.ipv6_cidr_blocks != null || r.security_groups != null
     ])
-    error_message = "Each rule must have a 'port' and at least one of 'cidr_blocks', 'ipv6_cidr_blocks', or 'security_groups'."
+    error_message = "Each rule must specify at least one of 'cidr_blocks', 'ipv6_cidr_blocks', or 'security_groups'."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -983,7 +983,7 @@ variable "gateway_api_internal_enabled" {
 }
 
 variable "gateway_api_external_alb_sg_rules" {
-  description = "Additional LB security group ingress rules for the external Gateway API ALB, appended to the module's own defaults (Cloudflare IPs or open_to_all) — this does not replace them."
+  description = "Additional ingress rules for the external Gateway API ALB's backend security group (terraform-aws-alb's backend_ingress_rules — the frontend SG is managed separately via Cloudflare IPs/open_to_all), appended to the module's own defaults — this does not replace them."
   type = list(object({
     description     = optional(string, "")
     protocol        = optional(string, "tcp")
@@ -991,7 +991,8 @@ variable "gateway_api_external_alb_sg_rules" {
     cidr_blocks     = optional(list(string))
     security_groups = optional(list(string))
   }))
-  default = []
+  default  = []
+  nullable = false
 
   validation {
     condition = alltrue([
@@ -1003,7 +1004,7 @@ variable "gateway_api_external_alb_sg_rules" {
 }
 
 variable "gateway_api_internal_alb_sg_rules" {
-  description = "Additional LB security group ingress rules for the internal Gateway API ALB, appended to the module's own defaults (HTTPS from all internal networks) — this does not replace them."
+  description = "Additional ingress rules for the internal Gateway API ALB's backend security group (terraform-aws-alb's backend_ingress_rules), appended to the module's own defaults (HTTPS from all internal networks) — this does not replace them."
   type = list(object({
     description     = optional(string, "")
     protocol        = optional(string, "tcp")
@@ -1011,7 +1012,8 @@ variable "gateway_api_internal_alb_sg_rules" {
     cidr_blocks     = optional(list(string))
     security_groups = optional(list(string))
   }))
-  default = []
+  default  = []
+  nullable = false
 
   validation {
     condition = alltrue([
@@ -1032,7 +1034,8 @@ variable "gateway_api_external_nlb_sg_rules" {
     ipv6_cidr_blocks = optional(list(string))
     security_groups  = optional(list(string))
   }))
-  default = []
+  default  = []
+  nullable = false
 
   validation {
     condition = alltrue([
@@ -1053,7 +1056,8 @@ variable "gateway_api_internal_nlb_sg_rules" {
     ipv6_cidr_blocks = optional(list(string))
     security_groups  = optional(list(string))
   }))
-  default = []
+  default  = []
+  nullable = false
 
   validation {
     condition = alltrue([


### PR DESCRIPTION
Requestor/Issue:
INFRA-6980

Tested (yes/no):
yes — `terraform test` (full suite): 65 passed, 0 failed. Includes 3 new regression tests added in this PR that reproduce the exact bug (confirmed failing before the fix, passing after) and verify the new additive semantics.

**Also validated live**, using this branch's commit as a temporary module source:

- `crypto-dev-eu-central-2` (`infrastructure#46628`, merged): migrated tx-proxy's Alchemy SG rules off the standalone-resource workaround onto `gateway_api_external_nlb_sg_rules`. Real TFE apply: `0 added, 1 changed, 8 destroyed`, no errors — but a live `describe-security-group-rules` check afterward caught a real gotcha (see note below): the Alchemy rules were actually missing post-apply. Fixed with a follow-up apply once identified; a subsequent plan now shows zero changes, confirmed stable.
- 4 other dev clusters not using the new override variables (`crypto-dev-us-east-1`, `security-dev-us-east-1`, `world-id-protocol-dev-us-east-1`, `internal-tools-dev-us-east-1`): plans came back with zero changes on this commit, confirming the fix is a no-op for existing callers.

**Note for anyone migrating an existing SG off a standalone-resource workaround onto this override:** don't trust a clean apply log alone. AWS's classic `DescribeSecurityGroups` groups ingress permissions by protocol+port regardless of which resource created them, so if identical rules already exist (added by the resource you're removing), the module's `aws_security_group` refresh silently absorbs them into its own tracked state — its "update" for those rules becomes a no-op (no real `AuthorizeSecurityGroupIngress` call), and the subsequent destroy of the old resource then genuinely revokes them with nothing re-adding them. Verify live with `aws ec2 describe-security-group-rules` after the transition apply; if rules are missing, a follow-up plan/apply against the drift adds them for real (no conflict, since the old resource is already gone from state).

Description/Why:
The four `gateway_api_{external,internal}_{alb,nlb}_sg_rules` override variables were structurally unusable for any override other than an exact clone of the module's own default. They were typed `any` and consumed as `var.X != null ? var.X : local.default`, but the module's own defaults are non-uniform-shaped tuples (different attribute keys per element — `cidr_blocks` vs `ipv6_cidr_blocks`). Terraform's type unification for a conditional expression requires both branches to share an identical tuple shape, so any override with a different length or attribute-key combination than the default failed at plan time with `Inconsistent conditional result types` — confirmed via a regression test reproducing the exact error, and via ~6 real-world repro variants during the original investigation (see INFRA-6980 for the full writeup).

Downstream, both `terraform-aws-nlb`'s `ingress_sg_rules` and `terraform-aws-alb`'s `backend_ingress_rules` are already properly typed (`set(object({...optional...}))`), so this bug was entirely self-inflicted in this module's own conditional expression — it never actually reached either child module.

**Fix, two parts:**

1. Type the four variables explicitly (`list(object({...optional...}))`) instead of `any`, matching what each downstream module (NLB/ALB) actually accepts. Default changed from `null` to `[]`.
2. Change semantics from full replacement to additive: the module's own default rules and the caller's override are now `concat()`'d together (with the default's own literal elements normalized to a uniform shape first, since `concat()` still needs consistent element types). Callers can now add rules without having to reproduce the Cloudflare/internal-network defaults themselves — this also matches how the one real caller of this variable was already trying to use it in practice (see the workaround in `infrastructure` PR #46068, which worked around this bug entirely by attaching rules outside the module instead).

Added 3 regression tests to `tests/kubernetes-gateway-api.tftest.hcl` covering: an override with a different shape/length than the default no longer breaks the plan, the defaults are preserved alongside an override (additive, not replaced), and the default-only case is unaffected when no override is set.

**Also found and flagged (not fixed here, out of scope):** `kubernetes-gw-int-alb.tf`'s internal-ALB default rule set has included an `ipv6_cidr_blocks` key on its conditional IPv6 rule, but `terraform-aws-alb`'s `backend_ingress_rules` type (checked `v1.6.1`, the version pinned here) has never had that attribute. This rule has likely been silently dropped at the module boundary in any environment with an IPv6 VPC CIDR — pre-existing, unrelated to the override-variable bug fixed here, left a comment in place flagging it.

**Downstream consumer:** `infrastructure`'s workaround for tx-proxy's Alchemy allowlist (INFRA-6750, `crypto/dev/eu-central-2/eks-cluster.tf`) bypassed this variable entirely with a standalone `aws_vpc_security_group_ingress_rule` resource attached directly to the module-managed SG — which had its own, separate problem (mixing inline-managed and separately-managed rules on the same SG, causing intermittent forced replacements). Migrated to use `gateway_api_external_nlb_sg_rules` properly in `infrastructure#46628` (merged) — see the live-validation note above for a real gotcha hit during that migration. Stage/prod (INFRA-6988/6989) follow once this PR is tagged.

AI usage/prompt(s) (if applicable):
Generated with Claude Code (claude-sonnet-5). Root cause and fix designed after reproducing the exact bug with a real `terraform test` run against this module (not just reading the ticket description), tracing the type-unification failure to this module's own ternary expressions, confirming both downstream modules (`terraform-aws-nlb`, `terraform-aws-alb`) are already correctly typed, and verifying the fix + additive semantics against the full existing test suite plus 3 new regression tests, plus a real live migration and multi-cluster no-op check on the `infrastructure` repo.
