### PR TITLE
INFRA-7080: add ecr-credentials-sync role and Pod Identity association

### DIFF
--- a/iam-ecr-credentials-sync.tf
+++ b/iam-ecr-credentials-sync.tf
@@ -1,0 +1,81 @@
+locals {
+  ecr_credentials_sync_namespace       = "argocd"
+  ecr_credentials_sync_service_account = "ecr-credentials-sync"
+}
+
+# INFRA-7080: the argocd/ecr-credentials-sync CronJob refreshes ArgoCD's ECR pull
+# and Helm credentials by running `aws ecr get-login-password`. Its ServiceAccount
+# has no IRSA role, so it used the node instance profile through IMDS. At IMDSv2
+# hop limit 1 the Pod cannot reach IMDS, so it is given credentials through Pod
+# Identity instead. The eks-pod-identity-agent addon serves them over a link-local
+# endpoint not subject to the hop limit. Modelled on the other baseline
+# pod-identity workloads in this module (kube-ops, vector): raw resources with a
+# cluster-scoped role name, so multiple clusters in one account do not collide.
+data "aws_iam_policy_document" "ecr_credentials_sync_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+
+    # https://docs.aws.amazon.com/eks/latest/userguide/pod-id-assign-target-role.html
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/eks-cluster-arn"
+      values   = [aws_eks_cluster.this.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/kubernetes-namespace"
+      values   = [local.ecr_credentials_sync_namespace]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/kubernetes-service-account"
+      values   = [local.ecr_credentials_sync_service_account]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecr_credentials_sync" {
+  count = var.ecr_credentials_sync_enabled ? 1 : 0
+
+  name               = trimsuffix(substr("ecr-credentials-sync-${var.cluster_name}", 0, 63), "-")
+  assume_role_policy = data.aws_iam_policy_document.ecr_credentials_sync_assume_role.json
+  path               = "/system/"
+
+  tags = {
+    namespace = local.ecr_credentials_sync_namespace
+  }
+}
+
+# The ECR token minted by this role is used by kubelet and ArgoCD to actually pull
+# images and Helm charts, and ECR authorizes those pulls against the identity that
+# minted the token. So the role needs the same read access the node role had (which
+# is what authorized these pulls before). AmazonEC2ContainerRegistryReadOnly grants
+# ecr:GetAuthorizationToken plus the pull actions (BatchGetImage,
+# GetDownloadUrlForLayer, BatchCheckLayerAvailability, ...).
+resource "aws_iam_role_policy_attachment" "ecr_credentials_sync" {
+  count = var.ecr_credentials_sync_enabled ? 1 : 0
+
+  role       = aws_iam_role.ecr_credentials_sync[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_eks_pod_identity_association" "ecr_credentials_sync" {
+  count = var.ecr_credentials_sync_enabled ? 1 : 0
+
+  cluster_name    = aws_eks_cluster.this.id
+  namespace       = local.ecr_credentials_sync_namespace
+  service_account = local.ecr_credentials_sync_service_account
+  role_arn        = aws_iam_role.ecr_credentials_sync[0].arn
+}

--- a/tests/ecr-credentials-sync.tftest.hcl
+++ b/tests/ecr-credentials-sync.tftest.hcl
@@ -1,0 +1,61 @@
+mock_provider "aws" {
+  source = "./tests/mocks/aws"
+}
+
+mock_provider "datadog" {}
+mock_provider "cloudflare" {}
+mock_provider "kubernetes" {
+  source = "./tests/mocks/kubernetes"
+}
+
+run "ecr_credentials_sync_iam_enabled_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(aws_iam_role.ecr_credentials_sync) == 1
+    error_message = "ecr-credentials-sync IAM role should be created by default."
+  }
+
+  assert {
+    condition     = length(aws_eks_pod_identity_association.ecr_credentials_sync) == 1
+    error_message = "ecr-credentials-sync pod identity association should be created by default."
+  }
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.ecr_credentials_sync[0].policy_arn == "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+    error_message = "ecr-credentials-sync role should attach AmazonEC2ContainerRegistryReadOnly for ECR pull authorization."
+  }
+
+  assert {
+    condition     = aws_iam_role.ecr_credentials_sync[0].name == "ecr-credentials-sync-eks-test"
+    error_message = "ecr-credentials-sync IAM role should be named from the cluster name."
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.ecr_credentials_sync[0].namespace == "argocd"
+    error_message = "ecr-credentials-sync pod identity association should use the argocd namespace."
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.ecr_credentials_sync[0].service_account == "ecr-credentials-sync"
+    error_message = "ecr-credentials-sync pod identity association should use the ecr-credentials-sync service account."
+  }
+}
+
+run "ecr_credentials_sync_iam_disabled" {
+  command = plan
+
+  variables {
+    ecr_credentials_sync_enabled = false
+  }
+
+  assert {
+    condition     = length(aws_iam_role.ecr_credentials_sync) == 0
+    error_message = "ecr-credentials-sync IAM role should not be created when disabled."
+  }
+
+  assert {
+    condition     = length(aws_eks_pod_identity_association.ecr_credentials_sync) == 0
+    error_message = "ecr-credentials-sync pod identity association should not be created when disabled."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,12 @@ variable "kube_ops_enabled" {
   default     = true
 }
 
+variable "ecr_credentials_sync_enabled" {
+  description = "Whether to create a role and Pod Identity association for the argocd/ecr-credentials-sync CronJob so it can call ecr:GetAuthorizationToken without IMDS"
+  type        = bool
+  default     = true
+}
+
 variable "extra_role_mapping" {
   description = "Extra role mappings to add to the aws-auth configmap."
   type = list(object({


### PR DESCRIPTION
## Requestor/Issue:
INFRA-7080 — https://linear.app/worldcoin/issue/INFRA-7080/give-ecr-credentials-sync-an-eks-pod-identity-role-fleet-wide
(part of INFRA-7052 — block Pod access to IMDSv2)

## Tested (yes/no):
yes (`terraform test` — tests/ecr-credentials-sync.tftest.hcl asserts the role, the AmazonEC2ContainerRegistryReadOnly attachment and the association exist by default, and are absent when ecr_credentials_sync_enabled = false; `terraform fmt`; README regenerated with terraform-docs).

## Description/Why:
Adds a first-class role and EKS Pod Identity association for the argocd/ecr-credentials-sync CronJob, alongside the module's other baseline pod-identity workloads (kube-ops, vector, ebs, keda, cni-metrics-helper).

ecr-credentials-sync refreshes ArgoCD's ECR pull and Helm credentials via `aws ecr get-login-password`. Its ServiceAccount has no IRSA role, so it minted the token as the node instance role through IMDS — unreachable from a Pod at IMDSv2 hop limit 1 (`NoCredentials`). It runs on every cluster (all 25) as part of the cluster-apps argocd-resources chart, with no per-cluster gate, so owning its IAM here means every cluster on this module gets the fix automatically and none is left half-covered when the hop limit is enabled.

- IAM role trusted by `pods.eks.amazonaws.com`, scoped by the standard session-tag conditions (cluster ARN, namespace `argocd`, service account `ecr-credentials-sync`).
- Cluster-scoped role name `ecr-credentials-sync-${cluster_name}`, matching kube-ops/vector, so multiple clusters in one account do not collide (the shared terraform-aws-iam pod-identity module names roles per-environment, which would; that module fits per-stack app roles, not a baseline workload here).
- Attaches `AmazonEC2ContainerRegistryReadOnly`: the minted token is used by kubelet and ArgoCD to pull images and Helm charts, and ECR authorizes those pulls against the identity that minted it — the same read access the node role provided.
- `aws_eks_pod_identity_association` for argocd/ecr-credentials-sync.
- Gated by `ecr_credentials_sync_enabled` (default true); additive, no change to existing resources.

## Rollout:
Additive and default-on. Cut a new tag; clusters pick it up as they bump the module ref (gradually, cluster by cluster). No cluster-apps change is needed — Pod Identity requires no ServiceAccount annotation. On any cluster that already carries a per-stack ecr-credentials-sync role/association (shared-tools-prod), remove that per-stack file in the same bump to avoid a duplicate association on (cluster, argocd, ecr-credentials-sync).

## AI usage/prompt(s) (if applicable):
Claude (Cowork). It diagnosed the ecr-credentials-sync Init:Error as NoCredentials at hop limit 1, established the CronJob runs on all 25 clusters with no per-cluster gate, confirmed the eks-pod-identity-agent addon is present and that the module's baseline pod-identity workloads use raw resources with cluster-scoped names, authored the role/attachment/association and test mirroring that pattern, and drafted this PR text.