### PR TITLE
INFRA-7070: add argocd-image-updater role and Pod Identity association

### DIFF
--- a/iam-argocd-image-updater.tf
+++ b/iam-argocd-image-updater.tf
@@ -1,0 +1,79 @@
+locals {
+  argocd_image_updater_namespace       = "argocd"
+  argocd_image_updater_service_account = "argocd-image-updater"
+}
+
+# INFRA-7070: argocd-image-updater polls ECR for newer image tags. Its
+# ServiceAccount carries no IRSA role, so it authenticates as the node instance
+# profile through IMDS, which a Pod cannot reach at IMDSv2 hop limit 1. It is given
+# its own identity through Pod Identity instead; the eks-pod-identity-agent addon
+# serves credentials over an endpoint not subject to the hop limit. Modelled on the
+# other baseline pod-identity workloads here (kube-ops, vector,
+# ecr-credentials-sync): raw resources with a cluster-scoped role name, so multiple
+# clusters in one account do not collide.
+data "aws_iam_policy_document" "argocd_image_updater_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+
+    # https://docs.aws.amazon.com/eks/latest/userguide/pod-id-assign-target-role.html
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/eks-cluster-arn"
+      values   = [aws_eks_cluster.this.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/kubernetes-namespace"
+      values   = [local.argocd_image_updater_namespace]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/kubernetes-service-account"
+      values   = [local.argocd_image_updater_service_account]
+    }
+  }
+}
+
+resource "aws_iam_role" "argocd_image_updater" {
+  count = var.argocd_image_updater_enabled ? 1 : 0
+
+  name               = trimsuffix(substr("argocd-image-updater-${var.cluster_name}", 0, 63), "-")
+  assume_role_policy = data.aws_iam_policy_document.argocd_image_updater_assume_role.json
+  path               = "/system/"
+
+  tags = {
+    namespace = local.argocd_image_updater_namespace
+  }
+}
+
+# Discovering newer tags needs ecr:GetAuthorizationToken to log in, then
+# DescribeRepositories / ListImages / DescribeImages to enumerate tags and
+# BatchGetImage to resolve a digest. AmazonEC2ContainerRegistryReadOnly grants all
+# of them, and is the same read access the node role provided.
+resource "aws_iam_role_policy_attachment" "argocd_image_updater" {
+  count = var.argocd_image_updater_enabled ? 1 : 0
+
+  role       = aws_iam_role.argocd_image_updater[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_eks_pod_identity_association" "argocd_image_updater" {
+  count = var.argocd_image_updater_enabled ? 1 : 0
+
+  cluster_name    = aws_eks_cluster.this.id
+  namespace       = local.argocd_image_updater_namespace
+  service_account = local.argocd_image_updater_service_account
+  role_arn        = aws_iam_role.argocd_image_updater[0].arn
+}

--- a/tests/argocd-image-updater.tftest.hcl
+++ b/tests/argocd-image-updater.tftest.hcl
@@ -1,0 +1,61 @@
+mock_provider "aws" {
+  source = "./tests/mocks/aws"
+}
+
+mock_provider "datadog" {}
+mock_provider "cloudflare" {}
+mock_provider "kubernetes" {
+  source = "./tests/mocks/kubernetes"
+}
+
+run "argocd_image_updater_iam_enabled_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(aws_iam_role.argocd_image_updater) == 1
+    error_message = "argocd-image-updater IAM role should be created by default."
+  }
+
+  assert {
+    condition     = length(aws_eks_pod_identity_association.argocd_image_updater) == 1
+    error_message = "argocd-image-updater pod identity association should be created by default."
+  }
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.argocd_image_updater[0].policy_arn == "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+    error_message = "argocd-image-updater role should attach AmazonEC2ContainerRegistryReadOnly to read ECR image tags."
+  }
+
+  assert {
+    condition     = aws_iam_role.argocd_image_updater[0].name == "argocd-image-updater-eks-test"
+    error_message = "argocd-image-updater IAM role should be named from the cluster name."
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.argocd_image_updater[0].namespace == "argocd"
+    error_message = "argocd-image-updater pod identity association should use the argocd namespace."
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.argocd_image_updater[0].service_account == "argocd-image-updater"
+    error_message = "argocd-image-updater pod identity association should use the argocd-image-updater service account."
+  }
+}
+
+run "argocd_image_updater_iam_disabled" {
+  command = plan
+
+  variables {
+    argocd_image_updater_enabled = false
+  }
+
+  assert {
+    condition     = length(aws_iam_role.argocd_image_updater) == 0
+    error_message = "argocd-image-updater IAM role should not be created when disabled."
+  }
+
+  assert {
+    condition     = length(aws_eks_pod_identity_association.argocd_image_updater) == 0
+    error_message = "argocd-image-updater pod identity association should not be created when disabled."
+  }
+}

--- a/tests/argocd-image-updater.tftest.hcl
+++ b/tests/argocd-image-updater.tftest.hcl
@@ -55,6 +55,11 @@ run "argocd_image_updater_iam_disabled" {
   }
 
   assert {
+    condition     = length(aws_iam_role_policy_attachment.argocd_image_updater) == 0
+    error_message = "argocd-image-updater policy attachment should not be created when disabled."
+  }
+
+  assert {
     condition     = length(aws_eks_pod_identity_association.argocd_image_updater) == 0
     error_message = "argocd-image-updater pod identity association should not be created when disabled."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,12 @@ variable "ecr_credentials_sync_enabled" {
   default     = true
 }
 
+variable "argocd_image_updater_enabled" {
+  description = "Whether to create a role and Pod Identity association for the argocd/argocd-image-updater Deployment so it can read ECR image tags without IMDS"
+  type        = bool
+  default     = true
+}
+
 variable "extra_role_mapping" {
   description = "Extra role mappings to add to the aws-auth configmap."
   type = list(object({


### PR DESCRIPTION
## Requestor/Issue:
INFRA-7070 — https://linear.app/worldcoin/issue/INFRA-7070/cluster-apps-give-argocd-image-updater-an-irsa-role
(part of INFRA-7052 — block Pod access to IMDSv2)

## Tested (yes/no):
yes — `terraform test` 70 passed / 0 failed, including the two new runs in `tests/argocd-image-updater.tftest.hcl`; `terraform fmt -check -recursive` clean. No apply; consumers are ref-pinned, so nothing changes until a cluster bumps its ref.

## Description/Why:
`argocd-image-updater` polls ECR for newer image tags. Its ServiceAccount has no IRSA role and no Pod Identity association, so it authenticates as the node instance profile through IMDS — unreachable from a Pod at IMDSv2 hop limit 1, which INFRA-7071 is rolling out. This gives it its own identity as a module baseline workload, alongside `kube-ops`, `vector`, `ebs`, `keda`, `cni-metrics-helper` and `ecr-credentials-sync`.

Verified live before implementing, on `orb-stage-v2-eu-central-1`, `orb-prod-v2-eu-central-1` and `world-id-protocol-stage-eu-central-1`:

- Deployment `argocd-image-updater-controller` in namespace `argocd`, `serviceAccountName: argocd-image-updater`
- no `AWS_*` credential env injected into the Pod
- the ServiceAccount carries no `eks.amazonaws.com/role-arn` annotation

So it has no identity of its own on any of them.

Changes:

- `iam-argocd-image-updater.tf` (new) — IAM role trusted by `pods.eks.amazonaws.com`, scoped by the standard session-tag conditions (cluster ARN, namespace `argocd`, service account `argocd-image-updater`); `AmazonEC2ContainerRegistryReadOnly` attachment; the Pod Identity association. Cluster-scoped role name `argocd-image-updater-${cluster_name}` so multiple clusters in one account do not collide.
- `variables.tf` — `argocd_image_updater_enabled`, default `true`.
- `tests/argocd-image-updater.tftest.hcl` (new) — asserts the role, attachment and association exist by default with the expected role name, namespace and service account, and are absent when the variable is `false`.

### Why the module rather than a role per cluster

The ticket originally scoped this as an IRSA role per cluster plus a ServiceAccount annotation in cluster-apps — seven roles and a cluster-apps change. This follows the shape #151 used for `ecr-credentials-sync` instead. Owning the IAM here means every cluster gets it on its next module bump, no cluster-apps change is needed at all (Pod Identity requires no annotation, unlike IRSA), and no cluster is left half-covered when the hop limit is enabled. It also covers clusters that turn image-updater on later.

### Scope of AmazonEC2ContainerRegistryReadOnly

Tag discovery needs `ecr:GetAuthorizationToken` to log in, then `DescribeRepositories` / `ListImages` / `DescribeImages` to enumerate tags, and `BatchGetImage` to resolve a digest. The managed policy grants all of them, and is the same read access the node role provided.

## Rollout:
Additive and default-on — no changes to existing resources. Cut a tag; clusters pick it up as they bump the module ref. `argocd-image-updater` is currently enabled on 7 clusters (`crypto-dev-eu-central-2`, `crypto-dev-us-east-1`, `orb-prod-v2-eu-central-1`, `orb-stage-v2-eu-central-1`, `world-id-protocol-stage-eu-central-1`, `world-id-protocol-stage-us-east-1`, `world-id-protocol-stage-ap-southeast-1`), but the role is created on every cluster, so nothing needs per-cluster gating. Verify on one: a restarted controller Pod gets `AWS_CONTAINER_CREDENTIALS_FULL_URI` injected and keeps resolving ECR tags.

Rollback: revert, which destroys the role and association; the controller falls back to IMDS, which is fine while the cluster is still at hop limit 2.

Note on the README: the inputs table is regenerated by the `docs` workflow on push to `main`, which opens its own "Update terraform docs" PR. Regenerating it in this branch also rewrote unrelated provider *version constraints* into resolved lockfile versions, so it is deliberately left to the workflow.

## AI usage/prompt(s) (if applicable):
Claude Code. It confirmed on three live clusters that the Deployment runs as `argocd/argocd-image-updater` with no injected AWS credentials and no IRSA annotation, established that the module already carries comparable baseline pod-identity workloads and mirrored that pattern, authored the role, attachment, association, variable and test, and ran `terraform fmt -check -recursive` and `terraform test`.
