### PR TITLE
INFRA-7070: document the Pod Identity convention and its auditing caveat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,14 @@ root folder represents STANDALONE module, and is expected to clear tests, work a
 - Always recommend using existing secret modules (e.g., terraform-aws-modules/secretmanager, 1Password integrations) already used in this repo.
 - This module is not to be used unconfigured/standalone. 
 
+## Workload AWS credentials — prefer Pod Identity
+
+- For baseline workloads this module owns, grant AWS access through **EKS Pod Identity**, not IRSA. Existing examples: `kube-ops`, `vector`, `ebs`, `keda`, `cni-metrics-helper`, `ecr-credentials-sync`, `argocd-image-updater`.
+- Pattern: raw `aws_iam_role` + `aws_iam_role_policy_attachment` + `aws_eks_pod_identity_association`; trust `pods.eks.amazonaws.com` scoped by the `eks-cluster-arn`, `kubernetes-namespace` and `kubernetes-service-account` session tags; cluster-scoped role name `<workload>-${var.cluster_name}` so several clusters in one account do not collide; gate on a `<workload>_enabled` variable defaulting to `true`. Copy `iam-ecr-credentials-sync.tf` as the template.
+- Why: no ServiceAccount annotation is needed, so IAM stays entirely in Terraform and no cluster-apps change is required; one trust policy shape works on every cluster; the session tags put cluster, namespace and service account into CloudTrail.
+- **Auditing caveat.** A Pod Identity association is invisible from inside the cluster — unlike IRSA there is no `eks.amazonaws.com/role-arn` annotation to grep for. Never conclude "no annotation, therefore no AWS identity". Check `aws eks list-pod-identity-associations --cluster-name <cluster>`, or look for `AWS_CONTAINER_CREDENTIALS_FULL_URI` in a running Pod.
+- Pod Identity is EKS-only and depends on the `eks-pod-identity-agent` addon being present. For a chart that must also run off EKS, IRSA or explicit credentials remain the only options.
+
 ## STRICTLY AVOID:
 - Propose large-scale provider upgrades (e.g., "bump AWS from 4.x to 6.x") unless the user asks.
 - Suggest moving resources between modules or renaming resources unless the user asks specifically.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ root folder represents STANDALONE module, and is expected to clear tests, work a
 - Pattern: raw `aws_iam_role` + `aws_iam_role_policy_attachment` + `aws_eks_pod_identity_association`; trust `pods.eks.amazonaws.com` scoped by the `eks-cluster-arn`, `kubernetes-namespace` and `kubernetes-service-account` session tags; cluster-scoped role name `<workload>-${var.cluster_name}` so several clusters in one account do not collide; gate on a `<workload>_enabled` variable defaulting to `true`. Copy `iam-ecr-credentials-sync.tf` as the template.
 - Why: no ServiceAccount annotation is needed, so IAM stays entirely in Terraform and no cluster-apps change is required; one trust policy shape works on every cluster; the session tags put cluster, namespace and service account into CloudTrail.
 - **Auditing caveat.** A Pod Identity association is invisible from inside the cluster — unlike IRSA there is no `eks.amazonaws.com/role-arn` annotation to grep for. Never conclude "no annotation, therefore no AWS identity". Check `aws eks list-pod-identity-associations --cluster-name <cluster>`, or look for `AWS_CONTAINER_CREDENTIALS_FULL_URI` in a running Pod.
-- Pod Identity is EKS-only and depends on the `eks-pod-identity-agent` addon being present. For a chart that must also run off EKS, IRSA or explicit credentials remain the only options.
+- Pod Identity is EKS-only and depends on the `eks-pod-identity-agent` addon being present. A chart that also has to run on a non-EKS cluster — `worldchain-ovh-a` is on OVH, not AWS — cannot use it there; IRSA or explicit credentials remain the only options for those.
 
 ## STRICTLY AVOID:
 - Propose large-scale provider upgrades (e.g., "bump AWS from 4.x to 6.x") unless the user asks.


### PR DESCRIPTION
## Requestor/Issue:
INFRA-7070 — https://linear.app/worldcoin/issue/INFRA-7070/terraform-aws-eks-give-argocd-image-updater-an-eks-pod-identity-role
(convention that came out of INFRA-7052 / INFRA-7080)

## Tested (yes/no):
no (documentation only, no Terraform touched).

## Description/Why:
Writes down the Pod Identity convention this module has been following implicitly, so the next baseline workload does not get an IRSA role by default and so the auditing trap below is not rediscovered the hard way.

The module already owns seven pod-identity workloads — `kube-ops`, `vector`, `ebs`, `keda`, `cni-metrics-helper`, `ecr-credentials-sync` and now `argocd-image-updater` (#152) — all built the same way, none of it documented. `AGENTS.md` gains a short section covering:

- prefer Pod Identity over IRSA for workloads this module owns, with `iam-ecr-credentials-sync.tf` named as the template
- the resource shape: role + managed policy attachment + association, trust scoped by the three session tags, cluster-scoped role name, `<workload>_enabled` variable defaulting to `true`
- why: IAM stays in Terraform, no cluster-apps change, one trust policy shape per fleet, cluster/namespace/service account land in CloudTrail
- **the auditing caveat**, which is the part worth reading

### The auditing caveat

A Pod Identity association leaves no trace inside the cluster. IRSA annotates the ServiceAccount with `eks.amazonaws.com/role-arn`, so "does this workload have an AWS identity?" is a grep. Pod Identity does not, so the same grep answers "no" for a workload that is perfectly well credentialed.

That produced four false positives during the INFRA-7052 IMDS audit — `vector`, `vector-audit`, `cni-metrics-helper` and `teleport-kube-agent` were all flagged as riding the node instance role when each already had Pod Identity. One nearly became a ticket. The section states the rule plainly and gives the two checks that actually work: `aws eks list-pod-identity-associations`, or `AWS_CONTAINER_CREDENTIALS_FULL_URI` in a running Pod.

Also recorded: Pod Identity is EKS-only and depends on the `eks-pod-identity-agent` addon, so a chart that must also run off EKS still needs IRSA or explicit credentials.

`CLAUDE.md` and `.github/copilot-instructions.md` are one-line pointers to `AGENTS.md`, so neither needs a change.

## AI usage/prompt(s) (if applicable):
Claude Code. It reconstructed the convention from the existing pod-identity workloads in this module, identified the in-cluster invisibility of associations as the cause of four false positives in its own earlier IMDS audit, and drafted the section and this PR text.
