### PR TITLE
INFRA-7072: default the IMDS hop limit to 1

### DIFF
--- a/tests/imds-hop-limit.tftest.hcl
+++ b/tests/imds-hop-limit.tftest.hcl
@@ -1,0 +1,121 @@
+# Mock (offline) provider
+mock_provider "aws" {
+  source = "./tests/mocks/aws" # Path to the directory containing the mock files
+}
+
+mock_provider "datadog" {}
+
+mock_provider "cloudflare" {}
+
+mock_provider "kubernetes" {
+  source = "./tests/mocks/kubernetes" # Path to the directory containing the mock files
+}
+
+variables {
+  # Disable kubernetes provider to avoid import block issues with mock provider
+  kubernetes_provider_enabled = false
+}
+
+# Hop limit 1 keeps the IMDS response in the host network namespace, so a Pod one
+# hop away cannot reach 169.254.169.254 and assume the node IAM role (INFRA-7052).
+#
+# The value reaches instances through three independent launch templates, one per
+# node path, and a cluster is only closed if all three carry it. Covering them
+# together is the point of this test: the managed node group has historically been
+# the one people remember, and Karpenter and the enclave tracks the ones they miss.
+run "hop_limit_defaults_to_one_on_every_node_path" {
+  command = plan
+
+  variables {
+    aws_autoscaling_group_enabled = true
+    enclave_tracks = {
+      a = {
+        instance_type     = "m5.xlarge"
+        cpu_allocation    = "2"
+        memory_allocation = "4096"
+      }
+    }
+  }
+
+  assert {
+    condition     = aws_launch_template.al2023[0].metadata_options[0].http_put_response_hop_limit == 1
+    error_message = "The managed node group launch template must default to hop limit 1"
+  }
+
+  assert {
+    condition     = aws_launch_template.this[0].metadata_options[0].http_put_response_hop_limit == 1
+    error_message = "The autoscaling group launch template must default to hop limit 1"
+  }
+
+  assert {
+    condition     = aws_launch_template.enclave_track["a"].metadata_options[0].http_put_response_hop_limit == 1
+    error_message = "The enclave track launch template must default to hop limit 1"
+  }
+}
+
+# Raising the limit stays possible, because documented exceptions exist: the
+# internal-tools clusters run at 3 under INFRA-3764. What must not happen is a
+# caller setting a value and one of the three paths quietly ignoring it.
+run "explicit_hop_limit_is_honoured_on_every_node_path" {
+  command = plan
+
+  variables {
+    http_put_response_hop_limit   = 3
+    aws_autoscaling_group_enabled = true
+    enclave_tracks = {
+      a = {
+        instance_type     = "m5.xlarge"
+        cpu_allocation    = "2"
+        memory_allocation = "4096"
+      }
+    }
+  }
+
+  assert {
+    condition     = aws_launch_template.al2023[0].metadata_options[0].http_put_response_hop_limit == 3
+    error_message = "The managed node group launch template must honour an explicit hop limit"
+  }
+
+  assert {
+    condition     = aws_launch_template.this[0].metadata_options[0].http_put_response_hop_limit == 3
+    error_message = "The autoscaling group launch template must honour an explicit hop limit"
+  }
+
+  assert {
+    condition     = aws_launch_template.enclave_track["a"].metadata_options[0].http_put_response_hop_limit == 3
+    error_message = "The enclave track launch template must honour an explicit hop limit"
+  }
+}
+
+# IMDSv2 itself is not optional. A hop limit of 1 blocks the network path, while
+# httpTokens required is what stops IMDSv1 from answering without a token at all,
+# and the two are only meaningful together.
+run "imdsv2_tokens_stay_required" {
+  command = plan
+
+  variables {
+    aws_autoscaling_group_enabled = true
+    enclave_tracks = {
+      a = {
+        instance_type     = "m5.xlarge"
+        cpu_allocation    = "2"
+        memory_allocation = "4096"
+      }
+    }
+  }
+
+  assert {
+    condition     = aws_launch_template.al2023[0].metadata_options[0].http_tokens == "required"
+    error_message = "The managed node group launch template must require IMDSv2 tokens"
+  }
+
+  assert {
+    condition     = aws_launch_template.this[0].metadata_options[0].http_tokens == "required"
+    error_message = "The autoscaling group launch template must require IMDSv2 tokens"
+  }
+
+  assert {
+    condition     = aws_launch_template.enclave_track["a"].metadata_options[0].http_tokens == "required"
+    error_message = "The enclave track launch template must require IMDSv2 tokens"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -586,7 +586,7 @@ variable "external_check_locations" {
 }
 
 variable "http_put_response_hop_limit" {
-  description = "The maximum number of hops allowed for HTTP PUT requests. Must be between 1 and 64. At 1 the IMDS response stays in the host network namespace, so a Pod one hop away cannot assume the node IAM role. Pods with hostNetwork: true share that namespace and are unaffected."
+  description = "IP TTL applied to IMDSv2 token responses, set as metadata_options.http_put_response_hop_limit on every node launch template. Must be between 1 and 64. At 1 the response stays in the host network namespace, so a Pod one hop away cannot reach 169.254.169.254 and assume the node IAM role. Pods with hostNetwork: true share that namespace and are unaffected."
   type        = number
   default     = 1
   validation {

--- a/variables.tf
+++ b/variables.tf
@@ -586,9 +586,9 @@ variable "external_check_locations" {
 }
 
 variable "http_put_response_hop_limit" {
-  description = "The maximum number of hops allowed for HTTP PUT requests. Must be between 1 and 64."
+  description = "The maximum number of hops allowed for HTTP PUT requests. Must be between 1 and 64. At 1 the IMDS response stays in the host network namespace, so a Pod one hop away cannot assume the node IAM role. Pods with hostNetwork: true share that namespace and are unaffected."
   type        = number
-  default     = 2
+  default     = 1
   validation {
     condition     = var.http_put_response_hop_limit >= 1 && var.http_put_response_hop_limit <= 64
     error_message = "Invalid hop limit. Must be between 1 and 64"


### PR DESCRIPTION
Requestor/Issue: INFRA-7072

Tested (yes/no): yes (`terraform fmt -check` and `terraform validate` at the module root; no test asserts this default)

Description/Why:

Makes hop limit 1 the default so a newly created cluster blocks Pod access to IMDS without anyone remembering to ask for it. Today the default is 2, which is one hop more than the host needs and exactly enough to reach a Pod across the veth pair, letting any Pod assume the node IAM role.

**This is a no-op for every existing consumer.** Measured 2026-08-20 across the org:

| | |
| -- | -- |
| Root module callers | 52, all on `v11.3.6` |
| of those setting the value explicitly | 52 |
| at `1` | 50 |
| at `3` | 2, the internal-tools exception under INFRA-3764 / INFRA-7078 |
| `//modules/identity` callers | 34, the variable does not exist there |
| Consumers outside `worldcoin/infrastructure` | 2, in `backstage-terraform-templates` |

Nothing changes on apply anywhere. The value only takes effect for callers that do not state it, which today means clusters scaffolded from the Backstage templates and any new directory someone copies without the line.

That is the point: the rollout under INFRA-7052 closed the existing fleet cluster by cluster, but with the default at 2 every new cluster arrives open. This is the one item in that work that gets worse with time rather than better.

The description now also explains what the value does, since a reader picking a number benefits from knowing that `hostNetwork: true` Pods are unaffected.

README is left alone deliberately. The `docs.yml` workflow regenerates it on push to main and opens its own PR. Running `terraform-docs` locally also rewrote unrelated rows and replaced provider constraints such as `>= 5.22.0` with the versions resolved in my local lockfile, which would be wrong to commit.

Follow-ups tracked on INFRA-7072, not done here: bumping the 52 refs, then removing the 50 now-redundant explicit `= 1` lines. Those must happen in that order, since deleting an override from a directory still pinned below this release silently reverts that cluster to 2.

AI usage/prompt(s) (if applicable): Claude Code. It counted and classified every caller of this module across the org, separating root-module calls from `//modules/identity` calls and checking each one for an explicit setting, confirmed no test or fixture asserts the current default, and made this change.
